### PR TITLE
get build + test compiling in 2018 edition

### DIFF
--- a/dynomite-derive/Cargo.toml
+++ b/dynomite-derive/Cargo.toml
@@ -20,8 +20,6 @@ travis-ci = { repository = "softprops/dynomite" }
 proc-macro = true
 
 [dependencies]
-rusoto_dynamodb = "0.36"
-dynomite = { version = "0.1.5", path = "../dynomite" }
 quote = "0.6.10"
 syn = "0.15.22"
 proc-macro2 = "0.4"
@@ -31,3 +29,4 @@ tokio = "0.1"
 futures = "0.1"
 rusoto_core = "0.36"
 uuid = { version = "0.7", features = ["v4"] }
+dynomite = { version = "0.1.5", path = "../dynomite" }

--- a/dynomite-derive/Cargo.toml
+++ b/dynomite-derive/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 documentation = "http://lessis.me/dynomite/dynomite_derive/"
 homepage = "https://github.com/softprops/dynomite"
 repository = "https://github.com/softprops/dynomite"
+edition = "2018"
 
 [badges]
 coveralls = { repository = "softprops/dynomite" }

--- a/dynomite-derive/examples/demo.rs
+++ b/dynomite-derive/examples/demo.rs
@@ -1,27 +1,14 @@
-#[macro_use]
-extern crate dynomite;
-#[macro_use]
-extern crate dynomite_derive;
-extern crate futures;
-extern crate rusoto_core;
-extern crate tokio;
-extern crate uuid;
-
-use std::sync::Arc;
-
-use dynamodb::{
-    AttributeDefinition, CreateTableInput, DynamoDb, DynamoDbClient, GetItemInput,
-    KeySchemaElement, ProvisionedThroughput, PutItemInput, ScanInput,
+use dynomite::{
+    attr_map,
+    dynamodb::{
+        AttributeDefinition, CreateTableInput, DynamoDb, DynamoDbClient, GetItemInput,
+        KeySchemaElement, ProvisionedThroughput, PutItemInput, ScanInput,
+    },
+    DynamoDbExt, FromAttributes, Item,
 };
-// dynomite re-exports `rusoto_dynamodb` for convenience
-use dynomite::dynamodb;
-// this enables extension methods on `DynamoDB` clients
-use dynomite::DynamoDbExt;
-// this enables a types to be coersed from attribute maps
-use dynomite::FromAttributes;
-// this enables `Item` methods on types which Item is implemented or derived for
-use dynomite::Item;
+use dynomite_derive::Item;
 use futures::{Future, Stream};
+use std::sync::Arc;
 use tokio::runtime::Runtime;
 use uuid::Uuid;
 

--- a/dynomite-derive/examples/local.rs
+++ b/dynomite-derive/examples/local.rs
@@ -1,28 +1,16 @@
-#[macro_use]
-extern crate dynomite;
-#[macro_use]
-extern crate dynomite_derive;
-extern crate futures;
-extern crate rusoto_core;
-extern crate tokio;
-extern crate uuid;
-
-use std::sync::Arc;
-
-use dynamodb::{
-    AttributeDefinition, CreateTableInput, DynamoDb, DynamoDbClient, GetItemInput,
-    KeySchemaElement, ProvisionedThroughput, PutItemInput, ScanInput,
+use dynomite::{
+    attr_map,
+    dynamodb::{
+        AttributeDefinition, CreateTableInput, DynamoDb, DynamoDbClient, GetItemInput,
+        KeySchemaElement, ProvisionedThroughput, PutItemInput, ScanInput,
+    },
+    DynamoDbExt, FromAttributes, Item,
 };
-// dynomite re-exports `rusoto_dynamodb` for convenience
-use dynomite::dynamodb;
-// this enables extension methods on `DynamoDB` clients
-use dynomite::DynamoDbExt;
-// this enables a types to be coersed from attribute maps
-use dynomite::FromAttributes;
-// this enables `Item` methods on types which Item is implemented or derived for
-use dynomite::Item;
+use dynomite_derive::Item;
+
 use futures::{Future, Stream};
 use rusoto_core::Region;
+use std::sync::Arc;
 use tokio::runtime::Runtime;
 use uuid::Uuid;
 

--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -4,12 +4,9 @@
 //! # examples
 //!
 //! ```
-//! #[macro_use]
-//! extern crate dynomite_derive;
-//! extern crate dynomite;
-//!
 //! use dynomite::{Item, FromAttributes, Attributes};
 //! use dynomite::dynamodb::AttributeValue;
+//! use dynomite_derive::Item;
 //!
 //! // derive Item
 //! #[derive(Item, PartialEq, Debug, Clone)]
@@ -36,15 +33,10 @@
 //! ```
 
 extern crate proc_macro;
-#[macro_use]
-extern crate quote;
-extern crate syn;
-// fixme: only needed for Ident::new(.., Span::call_site()) :/
-extern crate proc_macro2;
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::{
     Data::{Enum, Struct},
     DataStruct, DeriveInput, Field, Fields, Ident, Meta, Variant, Visibility,
@@ -58,13 +50,13 @@ pub fn derive_item(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(Attribute)]
-pub fn derive_attr(input: TokenStream) -> TokenStream {
+pub fn derive_attribute(input: TokenStream) -> TokenStream {
     let ast = syn::parse_macro_input!(input);
-    let gen = expand_attr(ast);
+    let gen = expand_attribute(ast);
     gen.into_token_stream().into()
 }
 
-fn expand_attr(ast: DeriveInput) -> impl ToTokens {
+fn expand_attribute(ast: DeriveInput) -> impl ToTokens {
     let name = &ast.ident;
     match ast.data {
         Enum(variants) => {

--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -42,6 +42,16 @@ use syn::{
     DataStruct, DeriveInput, Field, Fields, Ident, Meta, Variant, Visibility,
 };
 
+/// Derives `dynomite::Item` type for struts with named fields
+///
+/// # Attributes
+///
+/// * `#[hash]` - required attribute, expected to be applied the target [hash attribute](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.PrimaryKey) field with an derivable DynamoDB attribute value of String, Number or Binary
+/// * `#[range]` - optional attribute, may be applied to one target [range attribute](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.SecondaryIndexes) field with an derivable DynamoDB attribute value of String, Number or Binary
+///
+/// # Panics
+///
+/// This proc macro will panic when applied to other types
 #[proc_macro_derive(Item, attributes(hash, range))]
 pub fn derive_item(input: TokenStream) -> TokenStream {
     let ast = syn::parse_macro_input!(input);
@@ -49,6 +59,11 @@ pub fn derive_item(input: TokenStream) -> TokenStream {
     gen.into_token_stream().into()
 }
 
+/// Derives `dynomite::Attribute` for enum types
+///
+/// # Panics
+///
+/// This proc macro will panic when applied to other types
 #[proc_macro_derive(Attribute)]
 pub fn derive_attribute(input: TokenStream) -> TokenStream {
     let ast = syn::parse_macro_input!(input);

--- a/dynomite-derive/tests/derived.rs
+++ b/dynomite-derive/tests/derived.rs
@@ -1,7 +1,4 @@
-extern crate dynomite;
-#[macro_use]
-extern crate dynomite_derive;
-extern crate rusoto_dynamodb;
+use dynomite_derive::{Attribute, Item};
 
 #[derive(Item, Default, PartialEq, Debug, Clone)]
 pub struct Author {
@@ -31,10 +28,9 @@ pub struct Book {
 #[cfg(test)]
 mod tests {
 
-    use super::{
-        dynomite::{Attribute, Attributes, FromAttributes},
-        Book,
-    };
+    use super::Book;
+    use dynomite::{Attribute, Attributes, FromAttributes};
+    use dynomite_derive::Attribute;
 
     #[test]
     fn to_and_from_book() {

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 documentation = "https://softprops.github.io/dynomite"
 homepage = "https://github.com/softprops/dynomite"
 repository = "https://github.com/softprops/dynomite"
+edition = "2018"
 
 [badges]
 coveralls = { repository = "softprops/dynomite" }

--- a/dynomite/src/error.rs
+++ b/dynomite/src/error.rs
@@ -1,4 +1,5 @@
 //! Dynomite error types
+use failure::Fail;
 
 /// Errors that may result of attribute value conversions
 #[derive(Debug, Fail, PartialEq)]

--- a/dynomite/src/ext.rs
+++ b/dynomite/src/ext.rs
@@ -4,7 +4,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 // Third party
-use dynamodb::{
+use crate::dynamodb::{
     AttributeValue, BackupSummary, DynamoDb, ListBackupsError, ListBackupsInput, ListTablesError,
     ListTablesInput, QueryError, QueryInput, ScanError, ScanInput,
 };

--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -53,28 +53,21 @@
 //!
 
 #![deny(missing_docs)]
-#[macro_use]
-extern crate failure;
-extern crate futures;
-extern crate rusoto_core;
+
 // reexported
 // note: this is used inside the attr_map! macro
-pub extern crate rusoto_dynamodb as dynamodb;
-#[cfg(feature = "uuid")]
-extern crate uuid;
-
+pub use rusoto_dynamodb as dynamodb;
+use rusoto_dynamodb::AttributeValue;
 use std::collections::{HashMap, HashSet};
-
-use dynamodb::AttributeValue;
 #[cfg(feature = "uuid")]
 use uuid::Uuid;
 
 pub mod error;
 mod ext;
 
-pub use ext::DynamoDbExt;
-
-pub use error::AttributeError;
+/// re-export at crate level for convenience
+pub use crate::error::AttributeError;
+pub use crate::ext::DynamoDbExt;
 
 /// type alias for map of named attribute values
 pub type Attributes = HashMap<String, AttributeValue>;
@@ -85,8 +78,6 @@ pub type Attributes = HashMap<String, AttributeValue>;
 /// # Examples
 ///
 /// ```
-/// extern crate dynomite;
-///
 /// use std::collections::HashMap;
 /// use dynomite::{AttributeError, Item, Attribute, FromAttributes, Attributes};
 /// use dynomite::dynamodb::AttributeValue;
@@ -143,8 +134,6 @@ pub trait Item: Into<Attributes> + FromAttributes {
 /// # Examples
 ///
 /// ```
-/// extern crate dynomite;
-///
 /// use dynomite::Attribute;
 /// use dynomite::dynamodb::AttributeValue;
 ///
@@ -326,7 +315,7 @@ macro_rules! numeric_attr {
 macro_rules! numeric_collection_attr {
     ($type:ty => $collection:ty) => {
         impl Attribute for $collection {
-            fn into_attr(self) -> AttributeValue {
+            fn into_attr(self) -> crate::AttributeValue {
                 AttributeValue {
                     ns: Some(self.iter().map(|item| item.to_string()).collect()),
                     ..Default::default()
@@ -380,8 +369,8 @@ numeric_collection_attr!(f64 => Vec<f64>);
 /// ## Example
 ///
 /// ```
-/// #[macro_use] extern crate dynomite;
 /// use dynomite::dynamodb::QueryInput;
+/// use dynomite::attr_map;
 ///
 /// # fn main() {
 /// let query = QueryInput {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-# style function arg lists consistently
+# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#fn_args_density
 fn_args_density = "Vertical"
-# keep imports in order
+# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#merge_imports
 merge_imports = true


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

upgraded to 2018 edition.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

#### How did you verify your change:

cargo check/build/test

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

mention weird issue with having to use both `use dynomite::Item;` and `use dynomite_derive::Item;` until I figure out why you need both.