### PR TITLE
Added feature to use rustls instead of default for dependancy rusoto

### DIFF
--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -23,8 +23,9 @@ failure = "0.1"
 futures = "0.1"
 futures-backoff = "0.1"
 rusoto_core_default = { package = "rusoto_core", version = "0.38", optional = true }
-rusoto_core_rustls = { package = "rusoto_core", version = "0.38", default_features = false, features = ["rustls"], optional = true }
-rusoto_dynamodb = "0.38"
+rusoto_core_rustls = { package = "rusoto_core", version = "0.38", default_features = false, features=["rustls"], optional = true }
+rusoto_dynamodb_default = { package = "rusoto_dynamodb", version = "0.38", optional = true }
+rusoto_dynamodb_rustls = { package = "rusoto_dynamodb", version = "0.38", default_features = false, features=["rustls"], optional = true }
 uuid = { version = "0.7", features = ["v4"], optional = true }
 
 
@@ -35,6 +36,6 @@ serde_json = "1.0"
 tokio = "0.1"
 
 [features]
-default = ["uuid", "derive", "rusoto_core_default"]
-rustls = ["uuid", "derive", "rusoto_core_rustls"]
+default = ["uuid", "derive", "rusoto_core_default", "rusoto_dynamodb_default"]
+rustls = ["uuid", "derive", "rusoto_core_rustls", "rusoto_dynamodb_rustls"]
 derive = ["dynomite-derive"]

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -22,9 +22,11 @@ log = "0.4"
 failure = "0.1"
 futures = "0.1"
 futures-backoff = "0.1"
-rusoto_core = "0.38"
+rusoto_core_default = { package = "rusoto_core", version = "0.38", optional = true }
+rusoto_core_rustls = { package = "rusoto_core", version = "0.38", default_features = false, features = ["rustls"], optional = true }
 rusoto_dynamodb = "0.38"
 uuid = { version = "0.7", features = ["v4"], optional = true }
+
 
 [dev-dependencies]
 env_logger = "0.6"
@@ -33,5 +35,6 @@ serde_json = "1.0"
 tokio = "0.1"
 
 [features]
-default = ["uuid", "derive"]
+default = ["uuid", "derive", "rusoto_core_default"]
+rustls = ["uuid", "derive", "rusoto_core_rustls"]
 derive = ["dynomite-derive"]

--- a/dynomite/examples/demo.rs
+++ b/dynomite/examples/demo.rs
@@ -8,7 +8,13 @@ use dynomite::{
     DynamoDbExt, FromAttributes, Item, Retries,
 };
 use futures::{Future, Stream};
-use rusoto_core::Region;
+
+#[cfg(feature = "default")]
+use rusoto_core_default::Region;
+
+#[cfg(feature = "rustls")]
+use rusoto_core_rustls::Region;
+
 use tokio::runtime::Runtime;
 use uuid::Uuid;
 

--- a/dynomite/examples/local.rs
+++ b/dynomite/examples/local.rs
@@ -15,7 +15,13 @@ use dynomite::{
 };
 
 use futures::{Future, Stream};
-use rusoto_core::Region;
+
+#[cfg(feature = "default")]
+use rusoto_core_default::Region;
+
+#[cfg(feature = "rustls")]
+use rusoto_core_rustls::Region;
+
 use tokio::runtime::Runtime;
 use uuid::Uuid;
 

--- a/dynomite/src/ext.rs
+++ b/dynomite/src/ext.rs
@@ -5,7 +5,13 @@ use crate::dynamodb::{
     ListTablesInput, QueryError, QueryInput, ScanError, ScanInput,
 };
 use futures::{stream, Future, Stream};
-use rusoto_core::RusotoError;
+
+#[cfg(feature = "default")]
+use rusoto_core_default::RusotoError;
+
+#[cfg(feature = "rustls")]
+use rusoto_core_rustls::RusotoError;
+
 use std::collections::HashMap;
 
 type DynomiteStream<I, E> = Box<Stream<Item = I, Error = RusotoError<E>> + Send>;

--- a/dynomite/src/ext.rs
+++ b/dynomite/src/ext.rs
@@ -8,10 +8,8 @@ use futures::{stream, Future, Stream};
 
 #[cfg(feature = "default")]
 use rusoto_core_default::RusotoError;
-
 #[cfg(feature = "rustls")]
 use rusoto_core_rustls::RusotoError;
-
 use std::collections::HashMap;
 
 type DynomiteStream<I, E> = Box<Stream<Item = I, Error = RusotoError<E>> + Send>;

--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -66,8 +66,13 @@
 #![deny(missing_docs)]
 // reexported
 // note: this is used inside the attr_map! macro
-pub use rusoto_dynamodb as dynamodb;
-use rusoto_dynamodb::AttributeValue;
+#[cfg(feature = "default")]
+pub use rusoto_dynamodb_default as dynamodb;
+
+#[cfg(feature = "rustls")]
+pub use rusoto_dynamodb_rustls as dynamodb;
+
+use dynamodb::AttributeValue;
 use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},

--- a/dynomite/src/retry.rs
+++ b/dynomite/src/retry.rs
@@ -22,13 +22,10 @@
 use crate::dynamodb::*;
 use futures_backoff::{Condition, Strategy};
 use log::debug;
-
 #[cfg(feature = "default")]
 use rusoto_core_default::{RusotoError, RusotoFuture};
-
 #[cfg(feature = "rustls")]
 use rusoto_core_rustls::{RusotoError, RusotoFuture};
-
 use std::{sync::Arc, time::Duration};
 
 /// Preconfigured retry policies for failable operations

--- a/dynomite/src/retry.rs
+++ b/dynomite/src/retry.rs
@@ -22,7 +22,13 @@
 use crate::dynamodb::*;
 use futures_backoff::{Condition, Strategy};
 use log::debug;
-use rusoto_core::{RusotoError, RusotoFuture};
+
+#[cfg(feature = "default")]
+use rusoto_core_default::{RusotoError, RusotoFuture};
+
+#[cfg(feature = "rustls")]
+use rusoto_core_rustls::{RusotoError, RusotoFuture};
+
 use std::{sync::Arc, time::Duration};
 
 /// Preconfigured retry policies for failable operations


### PR DESCRIPTION
## What did you implement:

Closes: #50

#### How did you verify your change:
Ran tests using rustls and default features

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
Added feature to use rustls instead of default for dependancy rusoto

**Usage:** 
_Cargo.toml_
rusoto_core = { version = "0.38.0", default_features = false, features = ["rustls"] }
dynomite = { version = "0.4.0", default_features = false, features = ["rustls"] }
