### PR TITLE
Upgrade dynomite-derive to quote@1.0, syn@1.0, and proc-macro2@1.0

### DIFF
--- a/dynomite-derive/Cargo.toml
+++ b/dynomite-derive/Cargo.toml
@@ -20,6 +20,6 @@ travis-ci = { repository = "softprops/dynomite" }
 proc-macro = true
 
 [dependencies]
-quote = "0.6"
-syn = "0.15"
-proc-macro2 = "0.4"
+quote = "^1.0"
+syn = "^1.0"
+proc-macro2 = "^1.0"

--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -341,7 +341,14 @@ fn field_with_attribute(
 ) -> Option<Field> {
     let mut fields = fields.iter().cloned().filter(|field| {
         field.attrs.iter().any(|attr| match attr.parse_meta() {
-            Ok(Meta::Word(name)) => name == attribute_name,
+            Ok(Meta::Path(path)) => {
+                if path.segments.len() > 1 {
+                    return false;
+                }
+
+                let ident = &path.segments[0].ident;
+                ident == attribute_name
+            }
             _ => false,
         })
     });

--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -861,5 +861,4 @@ mod test {
             Ok(btreemap! { "foo".to_string() => 1 })
         );
     }
-
 }


### PR DESCRIPTION
## What did you implement:

Upgraded `dynomite-derive` to depend on `quote@1.0`, `syn@1.0`, and `proc-macro2@1.0`.

## Why was this done:

I would like to see https://github.com/softprops/dynomite/issues/53 implemented and figured this would be a good 0th step towards that goal.

#### How did you verify your change:

Ran `cargo test` and verified that every non-ignored test passed.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

`dynomite-derive`'s dependencies were bumped from `0.x` to `1.0`.
I do not know if you want to call this out in the changelog.