### PR TITLE
Add an explicit `dyn` to `DynomiteStream`

### DIFF
--- a/dynomite/src/ext.rs
+++ b/dynomite/src/ext.rs
@@ -12,7 +12,7 @@ use rusoto_core_default::RusotoError;
 use rusoto_core_rustls::RusotoError;
 use std::collections::HashMap;
 
-type DynomiteStream<I, E> = Box<Stream<Item = I, Error = RusotoError<E>> + Send>;
+type DynomiteStream<I, E> = Box<dyn Stream<Item = I, Error = RusotoError<E>> + Send>;
 
 /// Extension methods for DynamoDb client types
 ///


### PR DESCRIPTION
### What did you implement:

Added the `dyn` keyword to the `DynomiteStream` type alias.

Closes: https://github.com/softprops/dynomite/issues/67

### How did you verify your change:

Ran `cargo t` to verify that tests still pass.

### What (if anything) would need to be called out in the CHANGELOG for the next release:

Nothing.