### PR TITLE
Rename attributes `hash` to `partition_key` and `range` to `sort_key`

### DIFF
--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -465,7 +465,10 @@ fn get_item_trait(
     let partition_key_field = field_with_attribute(&fields, "partition_key");
     let sort_key_field = field_with_attribute(&fields, "sort_key");
 
-    let partition_key_insert = partition_key_field.as_ref().map(get_key_inserter).transpose()?;
+    let partition_key_insert = partition_key_field
+        .as_ref()
+        .map(get_key_inserter)
+        .transpose()?;
 
     let sort_key_insert = sort_key_field.as_ref().map(get_key_inserter).transpose()?;
 

--- a/dynomite/examples/demo.rs
+++ b/dynomite/examples/demo.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 
 #[derive(Item, Debug, Clone)]
 pub struct Book {
-    #[hash]
+    #[partition_key]
     id: Uuid,
     title: String,
 }

--- a/dynomite/examples/demo.rs
+++ b/dynomite/examples/demo.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 
 #[derive(Item, Debug, Clone)]
 pub struct Book {
-    #[partition_key]
+    #[dynomite(partition_key)]
     id: Uuid,
     title: String,
 }

--- a/dynomite/examples/local.rs
+++ b/dynomite/examples/local.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 
 #[derive(Item, Debug, Clone)]
 pub struct Book {
-    #[hash]
+    #[partition_key]
     id: Uuid,
     title: String,
 }

--- a/dynomite/examples/local.rs
+++ b/dynomite/examples/local.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 
 #[derive(Item, Debug, Clone)]
 pub struct Book {
-    #[partition_key]
+    #[dynomite(partition_key)]
     id: Uuid,
     title: String,
 }

--- a/dynomite/tests/derived.rs
+++ b/dynomite/tests/derived.rs
@@ -2,7 +2,7 @@ use dynomite_derive::{Attribute, Item};
 
 #[derive(Item, Default, PartialEq, Debug, Clone)]
 pub struct Author {
-    #[hash]
+    #[partition_key]
     name: String,
 }
 
@@ -19,7 +19,7 @@ impl Default for Category {
 
 #[derive(Item, Default, PartialEq, Debug, Clone)]
 pub struct Book {
-    #[hash]
+    #[partition_key]
     title: String,
     category: Category,
     authors: Option<Vec<Author>>,
@@ -27,7 +27,7 @@ pub struct Book {
 
 #[derive(Item, PartialEq, Debug, Clone)]
 struct Recipe {
-    #[hash]
+    #[partition_key]
     #[dynomite(rename = "recipe_id")]
     id: String,
     servings: u64,

--- a/dynomite/tests/derived.rs
+++ b/dynomite/tests/derived.rs
@@ -2,7 +2,7 @@ use dynomite_derive::{Attribute, Item};
 
 #[derive(Item, Default, PartialEq, Debug, Clone)]
 pub struct Author {
-    #[partition_key]
+    #[dynomite(partition_key)]
     name: String,
 }
 
@@ -19,7 +19,7 @@ impl Default for Category {
 
 #[derive(Item, Default, PartialEq, Debug, Clone)]
 pub struct Book {
-    #[partition_key]
+    #[dynomite(partition_key)]
     title: String,
     category: Category,
     authors: Option<Vec<Author>>,
@@ -27,7 +27,7 @@ pub struct Book {
 
 #[derive(Item, PartialEq, Debug, Clone)]
 struct Recipe {
-    #[partition_key]
+    #[dynomite(partition_key)]
     #[dynomite(rename = "recipe_id")]
     id: String,
     servings: u64,


### PR DESCRIPTION
## What did you implement:

Renamed attributes `hash` to `partition_key` and `range` to `sort_key`.

See reasoning in #69.

Closes: https://github.com/softprops/dynomite/issues/69

#### How did you verify your change:

```shell
$ cargo test # all non-ignored tests pass
```

```shell
$ rg -t rust -w hash | wc -l
       0

$ rg -t rust -w range | wc -l
       0

$ rg -t rust -w partition_key | wc -l
      10

$ rg -t rust -w sort_key | wc -l     
       4
```

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

This is a breaking change so we should call out the rename and _probably_ bump to `0.6`.