### PR TITLE
Rusoto 0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.1
+
+* Update rusoto dependencies to 0.41.0
+
 # 0.6.0
 
 * Breaking change. Rename Item attributes to align with current aws docs [#76](https://github.com/softprops/dynomite/pull/76)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 0.6.1
-
-* Update rusoto dependencies to 0.41.0
-
 # 0.6.0
 
 * Breaking change. Rename Item attributes to align with current aws docs [#76](https://github.com/softprops/dynomite/pull/76)

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -23,10 +23,10 @@ log = "0.4"
 failure = "0.1"
 futures = "0.1"
 futures-backoff = "0.1"
-rusoto_core_default = { package = "rusoto_core", version = "0.40", optional = true }
-rusoto_core_rustls = { package = "rusoto_core", version = "0.40", default_features = false, features=["rustls"], optional = true }
-rusoto_dynamodb_default = { package = "rusoto_dynamodb", version = "0.40", optional = true }
-rusoto_dynamodb_rustls = { package = "rusoto_dynamodb", version = "0.40", default_features = false, features=["rustls"], optional = true }
+rusoto_core_default = { package = "rusoto_core", version = "0.41.0", optional = true }
+rusoto_core_rustls = { package = "rusoto_core", version = "0.41.0", default_features = false, features=["rustls"], optional = true }
+rusoto_dynamodb_default = { package = "rusoto_dynamodb", version = "0.41.0", optional = true }
+rusoto_dynamodb_rustls = { package = "rusoto_dynamodb", version = "0.41.0", default_features = false, features=["rustls"], optional = true }
 uuid = { version = "0.7", features = ["v4"], optional = true }
 
 

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -23,10 +23,10 @@ log = "0.4"
 failure = "0.1"
 futures = "0.1"
 futures-backoff = "0.1"
-rusoto_core_default = { package = "rusoto_core", version = "0.41.0", optional = true }
-rusoto_core_rustls = { package = "rusoto_core", version = "0.41.0", default_features = false, features=["rustls"], optional = true }
-rusoto_dynamodb_default = { package = "rusoto_dynamodb", version = "0.41.0", optional = true }
-rusoto_dynamodb_rustls = { package = "rusoto_dynamodb", version = "0.41.0", default_features = false, features=["rustls"], optional = true }
+rusoto_core_default = { package = "rusoto_core", version = "0.41", optional = true }
+rusoto_core_rustls = { package = "rusoto_core", version = "0.41", default_features = false, features=["rustls"], optional = true }
+rusoto_dynamodb_default = { package = "rusoto_dynamodb", version = "0.41", optional = true }
+rusoto_dynamodb_rustls = { package = "rusoto_dynamodb", version = "0.41", default_features = false, features=["rustls"], optional = true }
 uuid = { version = "0.7", features = ["v4"], optional = true }
 
 


### PR DESCRIPTION
this change seems to be pretty safe, but I'm new to Rust; obviously feel free to disregard this pr if it's not wanted. This crate and serverless-rust made it really easy for a total beginner to get a Rust lambda up and running, so thanks for your work!

## What did you implement:
- bumped `rusoto_core` and `rusoto_dynamodb` to version `0.41`


#### How did you verify your change:
- `cargo build` in dynomite repo exits successfully
- using my fork and branch in Cargo.toml of my project (which uses 0.41 for rusoto_core and rusoto_dynamodb), 'cargo build' still builds successfully 

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
something along the lines of "bumped rusoto dependencies"