### PR TITLE
Update Rusoto 0.41 -> 0.42

### DIFF
--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -23,10 +23,10 @@ log = "0.4"
 failure = "0.1"
 futures = "0.1"
 futures-backoff = "0.1"
-rusoto_core_default = { package = "rusoto_core", version = "0.41", optional = true }
-rusoto_core_rustls = { package = "rusoto_core", version = "0.41", default_features = false, features=["rustls"], optional = true }
-rusoto_dynamodb_default = { package = "rusoto_dynamodb", version = "0.41", optional = true }
-rusoto_dynamodb_rustls = { package = "rusoto_dynamodb", version = "0.41", default_features = false, features=["rustls"], optional = true }
+rusoto_core_default = { package = "rusoto_core", version = "0.42", optional = true }
+rusoto_core_rustls = { package = "rusoto_core", version = "0.42", default_features = false, features=["rustls"], optional = true }
+rusoto_dynamodb_default = { package = "rusoto_dynamodb", version = "0.42", optional = true }
+rusoto_dynamodb_rustls = { package = "rusoto_dynamodb", version = "0.42", default_features = false, features=["rustls"], optional = true }
 uuid = { version = "0.8", features = ["v4"], optional = true }
 
 


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->



#### How did you verify your change:
Ran tests

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
Would need to bump minor version for dynomite as well as this breaks compilation if rusoto_dynamodb 0.41 is being pulled by the end user crate separately.