### PR TITLE
drop failure. std::error::Error is the common interface

### DIFF
--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -21,7 +21,6 @@ async-trait = "0.1"
 again = "0.1"
 bytes = "0.5"
 dynomite-derive = { version = "0.7.0", path = "../dynomite-derive", optional = true }
-failure = "0.1"
 futures = "0.3"
 log = "0.4"
 rusoto_core_default = { package = "rusoto_core", version = "0.43", optional = true }

--- a/dynomite/src/error.rs
+++ b/dynomite/src/error.rs
@@ -1,28 +1,48 @@
 //! Dynomite error types
-use failure::Fail;
+use std::{error::Error, fmt};
 
 /// Errors that may result of attribute value conversions
-#[derive(Debug, Fail, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum AttributeError {
     /// Will be returned if an AttributeValue is present, and is of the expected
     /// type but its contents are not well-formatted
-    #[fail(display = "Invalid format")]
     InvalidFormat,
     /// Will be returned if provided AttributeValue is not of the expected type
-    #[fail(display = "Invalid type")]
     InvalidType,
     /// Will be returned if provided attributes does not included an
     /// expected named value
-    #[fail(display = "Missing field {}", name)]
     MissingField {
         /// Name of the field that is missing
         name: String,
     },
 }
 
+impl fmt::Display for AttributeError {
+    fn fmt(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        match self {
+            AttributeError::InvalidFormat => write!(f, "Invalid format"),
+            AttributeError::InvalidType => write!(f, "Invalid type"),
+            AttributeError::MissingField { name } => write!(f, "Missing field {}", name),
+        }
+    }
+}
+
+impl Error for AttributeError {}
+
 #[cfg(test)]
 mod tests {
     use super::AttributeError;
+    use std::error::Error;
+
+    #[test]
+    fn attribute_error_impl_std_error() {
+        fn test(_: impl Error) {}
+        test(AttributeError::InvalidFormat)
+    }
+
     #[test]
     fn invalid_format_displays() {
         assert_eq!(


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

#### How did you verify your change:

tests

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

dropping failure crate dependency. it's not adding useful value. impl std error instead