### PR TITLE
fix recently appearing proc macro errors

### DIFF
--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -481,7 +481,7 @@ fn get_item_trait(
                 }
             }
         })
-        .unwrap_or(quote! {}))
+        .unwrap_or_else(proc_macro2::TokenStream::new))
 }
 
 /// Find a single `Field` from `fields` that has an attribute of the form
@@ -590,7 +590,7 @@ fn get_key_struct(
             })
         })
         .transpose()?
-        .unwrap_or(quote!());
+        .unwrap_or_else(proc_macro2::TokenStream::new);
 
     Ok(partition_key_field
         .map(|partition_key_field| {
@@ -602,7 +602,7 @@ fn get_key_struct(
                 }
             }
         })
-        .unwrap_or(quote!()))
+        .unwrap_or_else(proc_macro2::TokenStream::new))
 }
 
 /// Change `field.ident` to the value returned by `get_field_deser_name`


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

It seems that a recent change to clippy tripped some clippy errors on our proc macro impl. This fixes them

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

#### How did you verify your change:

#### What (if anything) would need to be called out in the CHANGELOG for the next release: