### PR TITLE
impl #[dynomite(default)] to gracefully handle sparse data

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,9 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '**'
   pull_request:
-    branches:
-      - master
 
 jobs:
   codestyle:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.0
+
+* Introduce new `#[dynomite(default)]` field attribute which permits the absence of fields values stored in ddb to be replaced with their default value when deserializing item data [#113](https://github.com/softprops/dynomite/pull/113)
+
 # 0.8.2
 
 * Bump rusoto dependencies to version `0.4.4`

--- a/dynomite-derive/Cargo.toml
+++ b/dynomite-derive/Cargo.toml
@@ -23,3 +23,4 @@ proc-macro = true
 quote = "^1.0"
 syn = "^1.0"
 proc-macro2 = "^1.0"
+proc-macro-error = "1.0"

--- a/dynomite-derive/src/attr.rs
+++ b/dynomite-derive/src/attr.rs
@@ -6,6 +6,7 @@ use syn::{
     Ident, LitStr, Token,
 };
 
+#[derive(Clone)]
 pub enum Attr {
     /// Denotes field should be replaced with Default impl when absent in ddb
     Default(Ident),

--- a/dynomite-derive/src/attr.rs
+++ b/dynomite-derive/src/attr.rs
@@ -1,0 +1,53 @@
+//! dynomite field attributes
+
+use proc_macro_error::abort;
+use syn::{
+    parse::{Parse, ParseStream},
+    Ident, LitStr, Token,
+};
+
+pub enum Attr {
+    /// Denotes field should be replaced with Default impl when absent in ddb
+    Default(Ident),
+    /// Denotes field should be renamed to value of ListStr
+    Rename(Ident, LitStr),
+    /// Denotes Item partition (primary) key
+    PartitionKey(Ident),
+    /// Denotes Item sort key
+    SortKey(Ident),
+}
+
+impl Parse for Attr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        use self::Attr::*;
+        let name: Ident = input.parse()?;
+        let name_str = name.to_string();
+        if input.peek(Token![=]) {
+            // `name = value` attributes.
+            let assign = input.parse::<Token![=]>()?; // skip '='
+            if input.peek(LitStr) {
+                let lit: LitStr = input.parse()?;
+                match &*name_str {
+                    "rename" => Ok(Rename(name, lit)),
+                    _ => unreachable!(),
+                }
+            } else {
+                abort! {
+                    assign,
+                    "expected `string literal` after `=`"
+                };
+            }
+        } else if input.peek(syn::token::Paren) {
+            // `name(...)` attributes.
+            abort!(name, "unexpected attribute: {}", name_str);
+        } else {
+            // Attributes represented with a sole identifier.
+            match name_str.as_ref() {
+                "default" => Ok(Default(name)),
+                "partition_key" => Ok(PartitionKey(name)),
+                "sort_key" => Ok(SortKey(name)),
+                _ => abort!(name, "unexpected attribute: {}", name_str),
+            }
+        }
+    }
+}

--- a/dynomite-derive/src/attr.rs
+++ b/dynomite-derive/src/attr.rs
@@ -29,7 +29,11 @@ impl Parse for Attr {
                 let lit: LitStr = input.parse()?;
                 match &*name_str {
                     "rename" => Ok(Rename(name, lit)),
-                    _ => unreachable!(),
+                    unsupported => abort! {
+                        name,
+                        "unsupported {} attribute",
+                        unsupported
+                    },
                 }
             } else {
                 abort! {

--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -227,10 +227,7 @@ fn make_dynomite_item(
     name: &Ident,
     fields: &[Field],
 ) -> syn::Result<impl ToTokens> {
-    let item_fields = fields
-        .into_iter()
-        .map(ItemField::new)
-        .collect::<Vec<_>>();
+    let item_fields = fields.into_iter().map(ItemField::new).collect::<Vec<_>>();
     // impl Item for Name + NameKey struct
     let dynamodb_traits = get_dynomite_item_traits(vis, name, &item_fields)?;
     // impl ::dynomite::FromAttributes for Name
@@ -350,7 +347,7 @@ fn get_from_attributes_function(fields: &[ItemField]) -> syn::Result<impl ToToke
         let field_deser_name = field.deser_name();
 
         let field_ident = &field.field.ident;
-        if default_when_absent(&field) {
+        if field.default_when_absent() {
             Ok(quote! {
                 #field_ident: match attrs.remove(#field_deser_name) {
                     Some(field) => #from_attribute_value(field)?,

--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -233,7 +233,7 @@ fn make_dynomite_item(
     name: &Ident,
     fields: &[Field],
 ) -> syn::Result<impl ToTokens> {
-    let item_fields = fields.into_iter().map(ItemField::new).collect::<Vec<_>>();
+    let item_fields = fields.iter().map(ItemField::new).collect::<Vec<_>>();
     // impl Item for Name + NameKey struct
     let dynamodb_traits = get_dynomite_item_traits(vis, name, &item_fields)?;
     // impl ::dynomite::FromAttributes for Name

--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -69,6 +69,12 @@ impl<'a> ItemField<'a> {
             .any(|attr| matches!(attr, Attr::SortKey(_)))
     }
 
+    fn is_default_when_absent(&self) -> bool {
+        self.attrs
+            .iter()
+            .any(|attr| matches!(attr, Attr::Default(_)))
+    }
+
     fn deser_name(&self) -> String {
         let ItemField { field, attrs } = self;
         attrs
@@ -329,14 +335,6 @@ fn get_from_attributes_trait(
     })
 }
 
-/// Field has #[dynomite(default)] attribute
-fn default_when_absent(field: &ItemField) -> bool {
-    field
-        .attrs
-        .iter()
-        .any(|attr| matches!(attr, Attr::Default(_)))
-}
-
 fn get_from_attributes_function(fields: &[ItemField]) -> syn::Result<impl ToTokens> {
     let attributes = quote!(::dynomite::Attributes);
     let from_attribute_value = quote!(::dynomite::Attribute::from_attr);
@@ -347,7 +345,7 @@ fn get_from_attributes_function(fields: &[ItemField]) -> syn::Result<impl ToToke
         let field_deser_name = field.deser_name();
 
         let field_ident = &field.field.ident;
-        if field.default_when_absent() {
+        if field.is_default_when_absent() {
             Ok(quote! {
                 #field_ident: match attrs.remove(#field_deser_name) {
                     Some(field) => #from_attribute_value(field)?,

--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -44,6 +44,7 @@ use syn::{
     DataStruct, DeriveInput, Field, Fields, Ident, Token, Variant, Visibility,
 };
 
+/// A Field and all its extracted dynomite derive attrs
 #[derive(Clone)]
 struct AnnotatedField<'a> {
     field: &'a Field,

--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -1,5 +1,4 @@
-//! Dynomite-derive provides procedural macros for deriving dynomite types
-//! for your structs
+//! Provides procedural macros for deriving dynomite types for your structs and enum types
 //!
 //! # Examples
 //!

--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -426,7 +426,6 @@ fn get_from_attributes_function(fields: &[Field]) -> syn::Result<impl ToTokens> 
                 )?
             })
         }
-        
     }).collect::<syn::Result<Vec<_>>>()?;
 
     Ok(quote! {

--- a/dynomite/examples/demo.rs
+++ b/dynomite/examples/demo.rs
@@ -23,6 +23,7 @@ use uuid::Uuid;
 pub struct Author {
     #[dynomite(partition_key)]
     id: Uuid,
+    #[dynomite(default)]
     name: String,
 }
 

--- a/dynomite/examples/local.rs
+++ b/dynomite/examples/local.rs
@@ -1,4 +1,4 @@
-/// Assumes a you are running  the following `dynamodb-local`
+/// Assumes a you are running the following `dynamodb-local`
 /// on your host machine
 ///
 /// ```bash

--- a/dynomite/examples/local.rs
+++ b/dynomite/examples/local.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 pub struct Book {
     #[dynomite(partition_key)]
     id: Uuid,
-    #[dynomite(rename = "bookTitle")]
+    #[dynomite(rename = "bookTitle", default)]
     title: String,
 }
 

--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -11,7 +11,7 @@
 //! The [Attribute](trait.Attribute.html) type
 //! provides conversion interfaces to and from Rust's native scalar types which represent
 //! DynamoDB's notion of "attributes". The goal of this type is to make representing
-//! AWS typed values feel more natural and ergonomic in Rust. You can implement `Attribute` for your own
+//! AWS typed values feel more natural and ergonomic in Rust. Where a conversion is not available you can implement `Attribute` for your own
 //! types to leverage higher level functionality.
 //!
 //! The [Item](trait.Item.html) type


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Like the title says, when you are dealing with dynamodb data you sometimes need to account for sparse data. This is different than the ddb [`NULL` type](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html). This is the case where the field is just not present at all. 

This change allows users to specify a new field attr for Items `#[dynomite(default)]` which is the mvp of dealing with an absent alternative `std::default::Default::default()`! Users will of course have to ensure their field type has a sensible default

Closes: #92

#### How did you verify your change:

1) update example code

2) cargo install cargo-expand # <-- best tool ever

3) cargo expand -p dynomite --example demo 

```rust
...
impl ::dynomite::FromAttributes for Author {
    fn from_attrs(
        mut attrs: ::dynomite::Attributes,
    ) -> ::std::result::Result<Self, ::dynomite::AttributeError> {
        ::std::result::Result::Ok(Self {
            id: ::dynomite::Attribute::from_attr(attrs.remove("id").ok_or(
                ::dynomite::AttributeError::MissingField {
                    name: "id".to_string(),
                },
            )?)?,
            name: match attrs.remove("name") {
                Some(field) => ::dynomite::Attribute::from_attr(field)?,
                _ => ::std::default::Default::default(), <-- note what happens here
            },
        })
    }
}
...
```



#### What (if anything) would need to be called out in the CHANGELOG for the next release: