### PR TITLE
Added a basic trybuild test case.

### DIFF
--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -37,6 +37,8 @@ maplit = "1.0"
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["macros"] }
 lambda_http = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "master"}
+trybuild = "1.0"
+dynomite-derive = { version = "0.8.2", path = "../dynomite-derive" } # required by trybuild
 
 [features]
 default = ["uuid", "chrono", "derive", "rusoto_core_default", "rusoto_dynamodb_default"]

--- a/dynomite/tests/try_build_test.rs
+++ b/dynomite/tests/try_build_test.rs
@@ -1,8 +1,6 @@
 //! Provides an error message testing framework using https://github.com/dtolnay/trybuild
 //! See `dynomite/trybuild-tests/readme.md` for instructions on how to add more tests.
 
-use trybuild;
-
 #[test]
 fn try_build_test() {
     println!("try-build");

--- a/dynomite/tests/try_build_test.rs
+++ b/dynomite/tests/try_build_test.rs
@@ -1,0 +1,11 @@
+//! Provides an error message testing framework using https://github.com/dtolnay/trybuild
+//! See `dynomite/trybuild-tests/readme.md` for instructions on how to add more tests.
+
+use trybuild;
+
+#[test]
+fn try_build_test() {
+    println!("try-build");
+    let t = trybuild::TestCases::new();
+    t.compile_fail("trybuild-tests/item-not-on-struct-fail.rs");
+}

--- a/dynomite/trybuild-tests/item-not-on-struct-fail.rs
+++ b/dynomite/trybuild-tests/item-not-on-struct-fail.rs
@@ -1,0 +1,12 @@
+use dynomite_derive::Item;
+
+fn main() {
+
+  fail();
+
+}
+
+#[derive(Item)]
+fn fail() {
+  println!("This should fail");
+}

--- a/dynomite/trybuild-tests/item-not-on-struct-fail.stderr
+++ b/dynomite/trybuild-tests/item-not-on-struct-fail.stderr
@@ -1,0 +1,5 @@
+error: `derive` may only be applied to structs, enums and unions
+ --> $DIR/item-not-on-struct-fail.rs:9:1
+  |
+9 | #[derive(Item)]
+  | ^^^^^^^^^^^^^^^

--- a/dynomite/trybuild-tests/readme.md
+++ b/dynomite/trybuild-tests/readme.md
@@ -1,0 +1,55 @@
+## How to add more tests
+
+- Create a test file in `test` folder, e.g. `item-not-on-struct-fail.rs`.
+- Write the least code needed to pass or fail. A fail will stop the crate from compiling.
+- Make sure you get the desired error message.
+- Move `item-not-on-struct-fail.rs` to `trybuild-tests` folder.
+- Add `t.compile_fail("trybuild-tests/item-not-on-struct-fail.rs");` (with your file name) to `dynomite/tests/try_build_test.rs`
+- Run `cargo test try_build_test`
+- You should see the following output:
+```
+test trybuild-tests/item-not-on-struct-fail.rs ... wip
+
+NOTE: writing the following output to `wip/item-not-on-struct-fail.stderr`.
+Move this file to `trybuild-tests/item-not-on-struct-fail.stderr` to accept it as correct.
+┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+error: `derive` may only be applied to structs, enums and unions
+ --> $DIR/item-not-on-struct-fail.rs:9:1
+  |
+9 | #[derive(Item)]
+  | ^^^^^^^^^^^^^^^
+┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+
+test try_build_test ... ok
+```
+- Check if the contents of this file contain the correct error message and no irrelevant info: `dynomite/wip/item-not-on-struct-fail.stderr`
+- Move `dynomite/wip/item-not-on-struct-fail.stderr` to `dynomite\trybuild-tests` folder, next to `item-not-on-struct-fail.rs` file
+- Re-run `cargo test try_build_test`
+- The test should pass OK with no error message, e.g. 
+```
+test trybuild-tests/item-not-on-struct-fail.rs ... ok
+
+test try_build_test ... ok
+```
+
+`trybuild` will now check the contents of the compiler error message against the the `.stderr` and flag it as OK as long as they match.
+
+#### t.compile_fail vs t.pass
+Use one or the other depending on the intent. See https://github.com/dtolnay/trybuild for more info.
+
+#### Test file location
+Test files that fail compilation should be placed outside the main project tree to avoid test/build compilation failures outside of _trybuild_ framework.
+E.g. this test snippet would prevent the project from building.
+```rust
+#[derive(Item)]
+fn fail() {
+  println!("This should fail");
+}
+```
+That was the sole reason for creating `dynomite/trybuild-tests` folder.
+
+#### dev-deps
+`dynomite-derive` has to be added to `[dev-dependencies]` for _trybuild_ to work
+
+#### trybuild ignores warnings
+It's either compile fail or pass. Compiler warnings cannot be checked for correctness with _trybuild_.


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

A basic error msg test with trybuild for derive tests as per issue #114

It is more of a placeholder with instructions how to add more tests.

#### How did you verify your change:

1. Run `cargo test try_build_test` - it should pass
2. Make an edit to `dynomite/trybuild-tests/item-not-on-struct-fail.stderr`
3. Run `cargo test try_build_test` - it should fail with `mismatch` error

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

* Added automated tests for error messages using `trybuild` framework.