### PR TITLE
Fix attr_map! macro: use $crate::attr_map! inside

### DIFF
--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -726,11 +726,11 @@ numeric_set_attr!(u64 => BTreeSet<u64>);
 /// };
 macro_rules! attr_map {
     (@single $($x:tt)*) => (());
-    (@count $($rest:expr),*) => (<[()]>::len(&[$(attr_map!(@single $rest)),*]));
-    ($($key:expr => $value:expr,)+) => { attr_map!($($key => $value),+) };
+    (@count $($rest:expr),*) => (<[()]>::len(&[$($crate::attr_map!(@single $rest)),*]));
+    ($($key:expr => $value:expr,)+) => { $crate::attr_map!($($key => $value),+) };
     ($($key:expr => $value:expr),*) => {
         {
-            let _cap = attr_map!(@count $($key),*);
+            let _cap = $crate::attr_map!(@count $($key),*);
             let mut _map: ::std::collections::HashMap<String, ::dynomite::dynamodb::AttributeValue> =
               ::std::collections::HashMap::with_capacity(_cap);
               {


### PR DESCRIPTION
## What did you implement:
Using `$crate` allows not requiring `attr_map!` be in scope, i.e. the following code will compile:
```rust
let foo = dynomite::attr_map! { "bar" => "baz".to_owned() }; 
```

#### How did you verify your change:
Didn't verify, merge for your own risk!

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
- Fix attr_map! macro: use $crate::attr_map! inside