### PR TITLE
Bump rusoto dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.1
+
+* Bump rusoto dependencies to version `0.45`
+
 # 0.9.0
 
 * Introduce new `#[dynomite(default)]` field attribute which permits the absence of field values in DynamoDB. These will be replaced with their default value when deserializing item data [#113](https://github.com/softprops/dynomite/pull/113)
@@ -23,7 +27,7 @@
 
 # 0.8.2
 
-* Bump rusoto dependencies to version `0.4.4`
+* Bump rusoto dependencies to version `0.44`
 
 # 0.8.1
 

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -24,10 +24,10 @@ bytes = "0.5"
 dynomite-derive = { version = "0.9.0", path = "../dynomite-derive", optional = true }
 futures = "0.3"
 log = "0.4"
-rusoto_core_default = { package = "rusoto_core", version = "0.44", optional = true }
-rusoto_core_rustls = { package = "rusoto_core", version = "0.44", default_features = false, features=["rustls"], optional = true }
-rusoto_dynamodb_default = { package = "rusoto_dynamodb", version = "0.44", optional = true }
-rusoto_dynamodb_rustls = { package = "rusoto_dynamodb", version = "0.44", default_features = false, features=["rustls"], optional = true }
+rusoto_core_default = { package = "rusoto_core", version = "0.45", optional = true }
+rusoto_core_rustls = { package = "rusoto_core", version = "0.45", default_features = false, features=["rustls"], optional = true }
+rusoto_dynamodb_default = { package = "rusoto_dynamodb", version = "0.45", optional = true }
+rusoto_dynamodb_rustls = { package = "rusoto_dynamodb", version = "0.45", default_features = false, features=["rustls"], optional = true }
 uuid = { version = "0.8", features = ["v4"], optional = true }
 chrono = { version = "0.4", optional = true }
 


### PR DESCRIPTION
## What did you implement:
Updated `rusoto*` dependencies to `0.45` version
I would appreciate if you could release this as a patch version to `cartes.io`, @softprops 

#### How did you verify your change:
```bash
cargo test # worked fine for me
```

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
Bump rusoto dependencies to version `0.45`