### PR TITLE
Fix ambient attrs propagated to the generated Key struct

### DIFF
--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -96,7 +96,7 @@ impl<'a> ItemField<'a> {
 fn parse_attrs(all_attrs: &[Attribute]) -> Vec<Attr> {
     all_attrs
         .iter()
-        .filter(|attr| attr.path.is_ident("dynomite"))
+        .filter(|attr| is_dynomite_attr(attr))
         .flat_map(|attr| {
             attr.parse_args_with(Punctuated::<Attr, Token![,]>::parse_terminated)
                 .unwrap_or_abort()
@@ -558,7 +558,9 @@ fn get_key_struct(
             // clone because this is a new struct
             // note: this in inherits field attrs so that
             // we retain dynomite(rename = "xxx")
-            let field = field.field.clone();
+            let mut field = field.field.clone();
+            field.attrs.retain(is_dynomite_attr);
+
             quote! {
                 #field
             }
@@ -572,7 +574,9 @@ fn get_key_struct(
             // clone because this is a new struct
             // note: this in inherits field attrs so that
             // we retain dynomite(rename = "xxx")
-            let field = field.field.clone();
+            let mut field = field.field.clone();
+            field.attrs.retain(is_dynomite_attr);
+
             quote! {
                 #field
             }
@@ -589,4 +593,8 @@ fn get_key_struct(
             }
         })
         .unwrap_or_else(proc_macro2::TokenStream::new))
+}
+
+fn is_dynomite_attr(suspect: &syn::Attribute) -> bool {
+    suspect.path.is_ident("dynomite")
 }

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -33,6 +33,7 @@ chrono = { version = "0.4", optional = true }
 [dev-dependencies]
 env_logger = "0.7"
 maplit = "1.0"
+serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["macros"] }
 lambda_http = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "master"}

--- a/dynomite/tests/derived.rs
+++ b/dynomite/tests/derived.rs
@@ -1,5 +1,5 @@
 use dynomite_derive::{Attribute, Item};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Item, Default, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct Author {

--- a/dynomite/tests/derived.rs
+++ b/dynomite/tests/derived.rs
@@ -1,8 +1,12 @@
 use dynomite_derive::{Attribute, Item};
+use serde::{Serialize, Deserialize};
 
-#[derive(Item, Default, PartialEq, Debug, Clone)]
+#[derive(Item, Default, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct Author {
     #[dynomite(partition_key)]
+    // Test that the serde attr is not propagated to the generated key
+    // Issue: https://github.com/softprops/dynomite/issues/121
+    #[serde(rename = "Name")]
     name: String,
 }
 


### PR DESCRIPTION
Fixes: https://github.com/softprops/dynomite/issues/121

#### How did you verify your change:

Added a test first (it doesn't compile on current version of dynomite)

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

Fix for #121

#### Additional info

@softprops I would like to ask you to release the 0.10.0 version to crates.io because current `dynomite` uses an outdated version of `rusoto_dynamodb` which conflicts with some other crates that depend on new version of `rusoto_dynamodb`.
You've mentioned this bug was the blocker for the release (https://github.com/softprops/dynomite/pull/123#issuecomment-671076955), so I suppose we can merge this and cut off `0.10.0` on `crates.io`?