### PR TITLE
Introduce #[dynomite(flatten)] attribute

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
         rust: [stable, beta, nightly]
     runs-on: ubuntu-latest
 
+    continue-on-error: ${{ matrix.rust != 'stable' }}
+
     steps:
     - name: Setup Rust
       uses: hecrj/setup-rust-action@v1
@@ -82,12 +84,12 @@ jobs:
       - name: Set up Rust
         uses: hecrj/setup-rust-action@v1
       - uses: actions/checkout@v2
-      - name: Publish        
+      - name: Publish
         run: |
           pushd dynomite-derive
           cargo publish --token ${{ secrets.CRATES_TOKEN }}
           popd
-          # eventual consistency dictates we wait a bit before publishing 
+          # eventual consistency dictates we wait a bit before publishing
           # a crate that depends on the above
           sleep 20
           pushd dynomite

--- a/dynomite-derive/src/attr.rs
+++ b/dynomite-derive/src/attr.rs
@@ -27,7 +27,10 @@ pub(crate) enum AttrKind {
 }
 
 impl Attr {
-    fn new(ident: Ident, kind: AttrKind) -> Self {
+    fn new(
+        ident: Ident,
+        kind: AttrKind,
+    ) -> Self {
         Self { ident, kind }
     }
 }

--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -286,8 +286,9 @@ fn make_dynomite_attributes(
     let item_fields = fields.iter().map(ItemField::new).collect::<Vec<_>>();
     // impl ::dynomite::FromAttributes for Name
     let from_attribute_map = get_from_attributes_trait(name, &item_fields);
+    // impl ::dynomite::IntoAttributes for Name
     // impl From<Name> for ::dynomite::Attributes
-    let to_attribute_map = get_to_attribute_map_trait(name, &item_fields)?;
+    let to_attribute_map = get_to_attribute_map_trait(name, &item_fields);
     // impl Attribute for Name (these are essentially just a map)
     let attribute = quote!(::dynomite::Attribute);
     let impl_attribute = quote! {
@@ -336,8 +337,9 @@ fn make_dynomite_item(
     let dynamodb_traits = get_dynomite_item_traits(vis, name, &item_fields)?;
     // impl ::dynomite::FromAttributes for Name
     let from_attribute_map = get_from_attributes_trait(name, &item_fields);
+    // impl ::dynomite::IntoAttributes for Name
     // impl From<Name> for ::dynomite::Attributes
-    let to_attribute_map = get_to_attribute_map_trait(name, &item_fields)?;
+    let to_attribute_map = get_to_attribute_map_trait(name, &item_fields);
 
     Ok(quote! {
         #from_attribute_map
@@ -349,10 +351,10 @@ fn make_dynomite_item(
 fn get_to_attribute_map_trait(
     name: &Ident,
     fields: &[ItemField],
-) -> syn::Result<impl ToTokens> {
+) -> impl ToTokens {
     let into_attrs_sink = get_into_attrs_sink_fn(fields);
 
-    Ok(quote! {
+    quote! {
         impl ::dynomite::IntoAttributes for #name {
             #into_attrs_sink
         }
@@ -362,7 +364,7 @@ fn get_to_attribute_map_trait(
                 ::dynomite::IntoAttributes::into_attrs(item)
             }
         }
-    })
+    }
 }
 
 fn get_into_attrs_sink_fn(fields: &[ItemField]) -> impl ToTokens {

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1.0"
 tokio = { version = "0.2", features = ["macros"] }
 lambda_http = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "master"}
 trybuild = "1.0"
+rustversion = "1.0"
 dynomite-derive = { version = "0.10.0", path = "../dynomite-derive" } # required by trybuild
 
 [features]

--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -197,7 +197,7 @@ pub type Attributes = HashMap<String, AttributeValue>;
 /// }
 ///
 /// // Unfortunately `dynomite` is not able to provide a blanket impl for this trait
-/// // due to orphan rules, but it generated via the `dynomite_derive` attributes
+/// // due to orphan rules, but it is generated via the `dynomite_derive` attributes
 /// impl From<Person> for Attributes {
 ///     fn from(person: Person) -> Attributes {
 ///         person.into_attrs()

--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //!
 //! ```rust,no_run
-//!  use dynomite::Item;
+//!  use dynomite::{Item, Attributes};
 //!  use uuid::Uuid;
 //!
 //! #[derive(Item)]
@@ -31,7 +31,25 @@
 //!   user: Uuid,
 //!   #[dynomite(sort_key)]
 //!   order_id: Uuid,
-//!   color: Option<String>
+//!   color: Option<String>,
+//! }
+//!
+//! #[derive(Item)]
+//! struct ShoppingCart {
+//!     #[dynomite(partition_key)]
+//!     id: Uuid,
+//!     // A separate struct to store data without any id
+//!     #[dynomite(flatten)]
+//!     data: ShoppingCartData,
+//! }
+//!
+//! // `Attributes` doesn't require neither of #[dynomite(partition_key/sort_key)]
+//! #[derive(Attributes)]
+//! struct ShoppingCartData {
+//!     // use Default value of the field if it is absent in DynamoDb
+//!     #[dynomite(default)]
+//!     orders: Vec<Order>,
+//!     name: String,
 //! }
 //! ```
 //!

--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -359,9 +359,9 @@ impl<A: Attribute> FromAttributes for BTreeMap<String, A> {
 }
 
 /// You should implement this trait instead of `From<T> for Attributes`
-/// for your type to support flattening, #[dynomite(Attributes/Item)] will
-/// generate both the implementation of this trait and `From<>`
-/// (there is no blanket impl for `From<>` here due to orphan rules)
+/// for your type to support flattening, `#[dynomite(Attributes/Item)]` will
+/// generate both the implementation of this trait and `From<T>`
+/// (there is no blanket impl for `From<T>` here due to orphan rules)
 pub trait IntoAttributes: Sized {
     /// A shortcut for `IntoAttributes::into_mut_attrs()` that creates a new hash map.
     /// You should generally implement only that method instead.

--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -308,6 +308,15 @@ pub trait Attribute: Sized {
     fn from_attr(value: AttributeValue) -> Result<Self, AttributeError>;
 }
 
+impl Attribute for AttributeValue {
+    fn into_attr(self: Self) -> AttributeValue {
+        self
+    }
+    fn from_attr(value: AttributeValue) -> Result<Self, AttributeError> {
+        Ok(value)
+    }
+}
+
 /// A type capable of being produced from
 /// a set of string keys and `AttributeValues`
 pub trait FromAttributes: Sized {

--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -66,7 +66,10 @@
 //! #     user: Uuid,
 //! #     order_id: Uuid,
 //! # }
-//! use dynomite::{Attributes, FromAttributes, dynamodb::{GetItemInput, DynamoDb}};
+//! use dynomite::{
+//!     dynamodb::{DynamoDb, GetItemInput},
+//!     Attributes, FromAttributes,
+//! };
 //! use std::error::Error;
 //! use uuid::Uuid;
 //!
@@ -80,15 +83,17 @@
 //!     // Convert stronly-typed `OrderKey` to a map of `rusoto_dynamodb::AttributeValue`
 //!     let key: Attributes = key.into();
 //!
-//!     let result = client.get_item(GetItemInput {
-//!         table_name: "orders".into(),
-//!         key,
-//!         ..Default::default()
-//!     }).await?;
+//!     let result = client
+//!         .get_item(GetItemInput {
+//!             table_name: "orders".into(),
+//!             key,
+//!             ..Default::default()
+//!         })
+//!         .await?;
 //!
-//!     Ok(result.item.map(|item| {
-//!         Order::from_attrs(item).expect("Invalid order, db corruption?")
-//!     }))
+//!     Ok(result
+//!         .item
+//!         .map(|item| Order::from_attrs(item).expect("Invalid order, db corruption?")))
 //! }
 //! ```
 //!

--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -308,15 +308,6 @@ pub trait Attribute: Sized {
     fn from_attr(value: AttributeValue) -> Result<Self, AttributeError>;
 }
 
-impl Attribute for AttributeValue {
-    fn into_attr(self: Self) -> AttributeValue {
-        self
-    }
-    fn from_attr(value: AttributeValue) -> Result<Self, AttributeError> {
-        Ok(value)
-    }
-}
-
 /// A type capable of being produced from
 /// a set of string keys and `AttributeValues`
 pub trait FromAttributes: Sized {

--- a/dynomite/src/retry.rs
+++ b/dynomite/src/retry.rs
@@ -16,7 +16,7 @@
 //!  // appropriate
 //!  let tables = client.list_tables(Default::default());
 //! ```
-//!
+
 use crate::dynamodb::*;
 use again::{Condition, RetryPolicy};
 use log::debug;

--- a/dynomite/tests/derived.rs
+++ b/dynomite/tests/derived.rs
@@ -57,7 +57,6 @@ struct FlattenedNested {
     c: bool,
 }
 
-
 #[cfg(test)]
 mod tests {
 
@@ -112,10 +111,7 @@ mod tests {
             id: "foo".into(),
             flat: Flattened {
                 a: true,
-                flat_nested: FlattenedNested {
-                    b: 42,
-                    c: false,
-                },
+                flat_nested: FlattenedNested { b: 42, c: false },
             },
         };
 

--- a/dynomite/tests/try_build_test.rs
+++ b/dynomite/tests/try_build_test.rs
@@ -1,6 +1,10 @@
 //! Provides an error message testing framework using https://github.com/dtolnay/trybuild
 //! See `dynomite/trybuild-tests/readme.md` for instructions on how to add more tests.
 
+// Try-build tests are run only on stable version of the toolchain. This is because
+// error messages in `rustc` change frequent enough to break the tests on beta or nightly
+// jobs.
+#[rustversion::stable]
 #[test]
 fn try_build_tests() {
     let t = trybuild::TestCases::new();

--- a/dynomite/trybuild-tests/fail/attributes-derived-unamed-fields-struct.rs
+++ b/dynomite/trybuild-tests/fail/attributes-derived-unamed-fields-struct.rs
@@ -1,11 +1,6 @@
-use dynomite_derive::Item;
+use dynomite_derive::Attributes;
 
-#[derive(Item)]
-struct Foo {
-    #[dynomite(partition_key)]
-    key1: String,
-    #[dynomite(typo)]
-    key2: String
-}
+#[derive(Attributes)]
+struct Foo(String);
 
 fn main() {}

--- a/dynomite/trybuild-tests/fail/attributes-derived-unamed-fields-struct.stderr
+++ b/dynomite/trybuild-tests/fail/attributes-derived-unamed-fields-struct.stderr
@@ -1,5 +1,5 @@
-error: unexpected dynomite attribute: typo
- --> $DIR/attributes-derived-unamed-fields-struct.rs:7:16
+error: Dynomite Attributes require named fields
+ --> $DIR/attributes-derived-unamed-fields-struct.rs:4:11
   |
-7 |     #[dynomite(typo)]
-  |                ^^^^
+4 | struct Foo(String);
+  |           ^^^^^^^^

--- a/dynomite/trybuild-tests/fail/default-with-flatten.rs
+++ b/dynomite/trybuild-tests/fail/default-with-flatten.rs
@@ -1,0 +1,14 @@
+use dynomite_derive::Attributes;
+
+#[derive(Attributes)]
+struct Foo {
+    #[dynomite(default, flatten)]
+    flat: Flattened
+}
+
+struct Flattened {
+    a: u32,
+}
+
+
+fn main() {}

--- a/dynomite/trybuild-tests/fail/default-with-flatten.stderr
+++ b/dynomite/trybuild-tests/fail/default-with-flatten.stderr
@@ -1,0 +1,5 @@
+error: If #[dynomite(flatten)] is used, no other dynomite attributes are allowed on the field
+ --> $DIR/default-with-flatten.rs:5:16
+  |
+5 |     #[dynomite(default, flatten)]
+  |                ^^^^^^^


### PR DESCRIPTION
## What did you implement:

This should be useful when we have fat enums support in `dynomite` (https://github.com/softprops/dynomite/issues/131), for enum variants to be able to be used as partition/sort keys.

This works like `#[serde(flatten)]`, the fields of the nested struct are flattened to the attributes of the surrounding struct where the flattened field is declared. The reverse mapping is done when parsing the struct from raw `Attributes`.

#### How did you verify your change:

Added a unit test, compile_fail test, and documentation (doc test)

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

* Introduce #[dynomite(flatten)] field attribute
**UPD**
* **BREAKING CHANGE** `FromAttributes` now requires the impl of `fn from_mut_attrs(attrs: &mut Attributes)` instead of `from_attrs(attrs: Attributes)`, the latter now has the default impl based on `from_mut_attrs` impl