### PR TITLE
Add initial support for fat enums (internally-tagged representation)

### DIFF
--- a/dynomite-derive/src/attr.rs
+++ b/dynomite-derive/src/attr.rs
@@ -6,14 +6,24 @@ use syn::{
     Ident, LitStr, Token,
 };
 
+/// Represents a parsed attribute that appears in `#[dynomite(...)]`.
 #[derive(Clone)]
-pub(crate) struct Attr {
+pub(crate) struct Attr<Kind> {
+    /// The identifier part of the attribute (e.g. `rename` in `#[dynomite(rename = "foo"`))
     pub(crate) ident: Ident,
-    pub(crate) kind: AttrKind,
+    /// More specific information about the metadata entry.
+    pub(crate) kind: Kind,
 }
 
+/// Attribute that appears on record fields (struct fields and enum record variant fields)
+pub(crate) type FieldAttr = Attr<FieldAttrKind>;
+/// Attribute that appears on the top level of an enum
+pub(crate) type EnumAttr = Attr<EnumAttrKind>;
+/// Attribute that appears on enum varinats
+pub(crate) type VariantAttr = Attr<VariantAttrKind>;
+
 #[derive(Clone)]
-pub(crate) enum AttrKind {
+pub(crate) enum FieldAttrKind {
     /// Denotes field should be replaced with Default impl when absent in ddb
     Default,
     /// Denotes field should be renamed to value of ListStr
@@ -26,51 +36,122 @@ pub(crate) enum AttrKind {
     Flatten,
 }
 
-impl Attr {
-    fn new(
-        ident: Ident,
-        kind: AttrKind,
-    ) -> Self {
-        Self { ident, kind }
+impl DynomiteAttr for FieldAttrKind {
+    const KVS: Kvs<Self> = &[("rename", FieldAttrKind::Rename)];
+    const KEYS: Keys<Self> = &[
+        ("default", FieldAttrKind::Default),
+        ("partition_key", FieldAttrKind::PartitionKey),
+        ("sort_key", FieldAttrKind::SortKey),
+        ("flatten", FieldAttrKind::Flatten),
+    ];
+}
+
+#[derive(Clone)]
+pub(crate) enum EnumAttrKind {
+    // FIXME: implement content attribute to support non-map values in enum variants
+    // (adjacently tagged enums: https://serde.rs/enum-representations.html#adjacently-tagged)
+    // Content(LitStr),
+    /// The name of the tag field for an internally-tagged enum
+    Tag(LitStr),
+}
+
+impl DynomiteAttr for EnumAttrKind {
+    const KVS: Kvs<Self> = &[("tag", EnumAttrKind::Tag)];
+}
+#[derive(Clone)]
+pub(crate) enum VariantAttrKind {
+    // TODO: add default for enum variants?
+    Rename(LitStr),
+}
+
+impl DynomiteAttr for VariantAttrKind {
+    const KVS: Kvs<Self> = &[("rename", VariantAttrKind::Rename)];
+}
+
+type Kvs<T> = &'static [(&'static str, fn(syn::LitStr) -> T)];
+type Keys<T> = &'static [(&'static str, T)];
+
+/// Helper to ease defining `#[dynomite(key)` and `#[dynomite(key = "val")` attributes
+pub(crate) trait DynomiteAttr: Clone + Sized + 'static {
+    /// List of `("attr_name", enum_variant_constructor)` to define attributes
+    /// that require a value string literal (e.g. `rename = "foo"`)
+    const KVS: Kvs<Self> = &[];
+    /// List of `("attr_name", enum_variant_value)` entires to define attributes
+    /// that should not have any value (e.g. `default` or `flatten`)
+    const KEYS: Keys<Self> = &[];
+}
+
+impl<A: DynomiteAttr> Parse for Attr<A> {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let entry: MetadataEntry = input.parse()?;
+        let kind = entry
+            .try_attr_with_val(A::KVS)
+            .or_else(|| entry.try_attr_without_val(A::KEYS))
+            .unwrap_or_else(|| abort!(entry.key, "unexpected dynomite attribute: {}", entry.key));
+        Ok(Attr {
+            ident: entry.key,
+            kind,
+        })
     }
 }
 
-impl Parse for Attr {
+struct MetadataEntry {
+    key: Ident,
+    val: Option<LitStr>,
+}
+
+impl MetadataEntry {
+    /// Attempt to map the parsed entry to an identifier-only attribute from the list
+    fn try_attr_without_val<T: Clone>(
+        &self,
+        mappings: Keys<T>,
+    ) -> Option<T> {
+        let Self { key, val } = self;
+        let key_str = key.to_string();
+        mappings
+            .iter()
+            .find(|(key_pat, _)| *key_pat == key_str)
+            .map(|(_, enum_val)| match val {
+                Some(_) => abort!(key, "expected no value for dynomite attribute `{}`", key),
+                None => enum_val.clone(),
+            })
+    }
+
+    /// Attempt to map the parsed entry to a key-value attribute from the list
+    fn try_attr_with_val<T>(
+        &self,
+        mappings: Kvs<T>,
+    ) -> Option<T> {
+        let Self { key, val } = self;
+        let key_str = key.to_string();
+        mappings
+            .iter()
+            .find(|(key_pat, _)| *key_pat == key_str)
+            .map(|(_, to_enum)| match val {
+                Some(it) => to_enum(it.clone()),
+                None => abort!(
+                    key,
+                    "expected a value for dynomite attribute: `{} = \"foo\"`",
+                    key
+                ),
+            })
+    }
+}
+
+impl Parse for MetadataEntry {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let name: Ident = input.parse()?;
-        let name_str = name.to_string();
-        if input.peek(Token![=]) {
-            // `name = value` attributes.
-            let assign = input.parse::<Token![=]>()?; // skip '='
-            if input.peek(LitStr) {
-                let lit: LitStr = input.parse()?;
-                match &*name_str {
-                    "rename" => Ok(Attr::new(name, AttrKind::Rename(lit))),
-                    unsupported => abort! {
-                        name,
-                        "unsupported dynomite {} attribute",
-                        unsupported
-                    },
-                }
-            } else {
-                abort! {
-                    assign,
-                    "expected `string literal` after `=`"
-                };
-            }
-        } else if input.peek(syn::token::Paren) {
+        let key: Ident = input.parse()?;
+        if input.peek(syn::token::Paren) {
             // `name(...)` attributes.
-            abort!(name, "unexpected dynomite attribute: {}", name_str);
-        } else {
-            // Attributes represented with a sole identifier.
-            let kind = match name_str.as_ref() {
-                "default" => AttrKind::Default,
-                "partition_key" => AttrKind::PartitionKey,
-                "sort_key" => AttrKind::SortKey,
-                "flatten" => AttrKind::Flatten,
-                _ => abort!(name, "unexpected dynomite attribute: {}", name_str),
-            };
-            Ok(Attr::new(name, kind))
+            abort!(key, "unexpected paren in dynomite attribute: {}", key);
         }
+        Ok(Self {
+            key,
+            val: input
+                .parse::<Token![=]>()
+                .ok()
+                .map(|_| input.parse())
+                .transpose()?,
+        })
     }
 }

--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -29,24 +29,200 @@
 //! ```
 
 mod attr;
-use attr::{Attr, AttrKind};
+use std::collections::HashSet;
+
+use attr::{EnumAttr, EnumAttrKind, FieldAttr, FieldAttrKind, VariantAttr};
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro_error::{abort, ResultExt};
 use quote::{quote, ToTokens};
 use syn::{
-    punctuated::Punctuated,
-    Attribute,
-    Data::{Enum, Struct},
-    DataStruct, DeriveInput, Field, Fields, Ident, Token, Variant, Visibility,
+    parse::Parse, punctuated::Punctuated, Attribute, DataStruct, DeriveInput, Field, Fields, Ident,
+    Token, Visibility,
 };
+
+struct Variant {
+    inner: syn::Variant,
+    attrs: Vec<VariantAttr>,
+}
+
+impl Variant {
+    fn deser_name(&self) -> String {
+        self.attrs
+            .iter()
+            .find_map(|it| match &it.kind {
+                attr::VariantAttrKind::Rename(it) => Some(it.value()),
+            })
+            .unwrap_or_else(|| self.inner.ident.to_string())
+    }
+}
+
+struct DataEnum {
+    attrs: Vec<EnumAttr>,
+    ident: syn::Ident,
+    variants: Vec<Variant>,
+}
+
+impl DataEnum {
+    fn new(
+        ident: Ident,
+        inner: syn::DataEnum,
+        attrs: &[Attribute],
+    ) -> Self {
+        let me = Self {
+            attrs: parse_attrs(&attrs),
+            ident,
+            variants: inner
+                .variants
+                .into_iter()
+                .map(|inner| {
+                    let attrs = parse_attrs(&inner.attrs);
+                    Variant { inner, attrs }
+                })
+                .collect(),
+        };
+
+        // Validate that all enum tag values are unique
+        let mut unique_names = HashSet::new();
+        for variant in &me.variants {
+            if let Some(existing) = unique_names.replace(variant.deser_name()) {
+                abort!(
+                    variant.inner.ident.span(),
+                    "Duplicate tag name detected: `{}`", existing;
+                    help = "Please ensure that no `rename = \"tag_value\"` \
+                    clauses conflict with each other and remaining enum variants' names"
+                );
+            }
+        }
+        me
+    }
+
+    fn tag_key(&self) -> String {
+        self.attrs
+            .iter()
+            .find_map(|attr| match &attr.kind {
+                EnumAttrKind::Tag(lit) => Some(lit.value()),
+            })
+            .unwrap_or_else(|| {
+                abort!(
+                    self.ident,
+                    "#[derive(Attributes)] for fat enums must have a sibling \
+                    #[dynomite(tag = \"key\")] attribute to specify the descriptor field name.";
+                    note = "Only internally tagged enums are supported in this version of dynomite."
+                )
+            })
+    }
+
+    fn impl_from_attributes(&self) -> impl ToTokens {
+        let match_arms = self.variants.iter().map(|variant| {
+            let variant_ident = &variant.inner.ident;
+            let expr = match &variant.inner.fields {
+                Fields::Named(_record) => Self::unimplemented_record_variants(&variant),
+                Fields::Unnamed(tuple) => {
+                    Self::expect_single_item_tuple(&tuple, variant_ident);
+                    quote! { Self::#variant_ident(::dynomite::FromAttributes::from_mut_attrs(attrs)?) }
+                }
+                Fields::Unit => quote! { Self::#variant_ident }
+            };
+            let variant_deser_name = variant.deser_name();
+            quote! { #variant_deser_name => #expr, }
+        });
+
+        let enum_ident = &self.ident;
+        let tag_key = self.tag_key();
+        quote! {
+            impl ::dynomite::FromAttributes for #enum_ident {
+                fn from_mut_attrs(attrs: &mut ::dynomite::Attributes) -> ::std::result::Result<Self, ::dynomite::AttributeError> {
+                    use ::std::{string::String, result::Result::{Ok, Err}};
+                    use ::dynomite::{Attribute, AttributeError};
+
+                    let tag = attrs.remove(#tag_key).ok_or_else(|| {
+                        AttributeError::MissingField {
+                            name: #tag_key.to_owned(),
+                        }
+                    })?;
+                    let tag: String = Attribute::from_attr(tag)?;
+                    Ok(match tag.as_str() {
+                        #(#match_arms)*
+                        _ => return Err(AttributeError::InvalidFormat)
+                    })
+                }
+            }
+        }
+    }
+
+    fn impl_into_attributes(&self) -> impl ToTokens {
+        let enum_ident = &self.ident;
+
+        let match_arms = self.variants.iter().map(|variant| {
+            let variant_ident = &variant.inner.ident;
+            let variant_deser_name = variant.deser_name();
+            match &variant.inner.fields {
+                Fields::Named(_record) => Self::unimplemented_record_variants(&variant),
+                Fields::Unnamed(tuple) => {
+                    Self::expect_single_item_tuple(&tuple, variant_ident);
+
+                    quote! {
+                        Self::#variant_ident(variant) => {
+                            ::dynomite::IntoAttributes::into_mut_attrs(variant, attrs);
+                            #variant_deser_name
+                        }
+                    }
+                }
+                Fields::Unit => quote! { Self::#variant_ident => #variant_deser_name, },
+            }
+        });
+
+        let tag_key = self.tag_key();
+
+        quote! {
+            impl ::dynomite::IntoAttributes for #enum_ident {
+                fn into_mut_attrs(self, attrs: &mut ::dynomite::Attributes) {
+                    let tag = match self {
+                        #(#match_arms)*
+                    };
+                    let tag = ::dynomite::Attribute::into_attr(tag.to_owned());
+                    attrs.insert(#tag_key.to_owned(), tag);
+                }
+            }
+
+            impl ::std::convert::From<#enum_ident> for ::dynomite::Attributes {
+                fn from(item: #enum_ident) -> Self {
+                    ::dynomite::IntoAttributes::into_attrs(item)
+                }
+            }
+        }
+    }
+
+    fn unimplemented_record_variants(variant: &Variant) -> ! {
+        abort!(
+            variant.inner.ident.span(),
+            "Record enum variants are not implemented yet."
+        )
+    }
+
+    fn expect_single_item_tuple(
+        tuple: &syn::FieldsUnnamed,
+        variant_ident: &Ident,
+    ) {
+        if tuple.unnamed.len() != 1 {
+            abort!(
+                variant_ident,
+                "Tuple variants with {} elements are not supported yet in dynomite, use \
+                single-element tuples for now. \
+                This restriction may be relaxed in future (follow the updates).",
+                tuple.unnamed.len(),
+            )
+        }
+    }
+}
 
 /// A Field and all its extracted dynomite derive attrs
 #[derive(Clone)]
 struct ItemField<'a> {
     field: &'a Field,
-    attrs: Vec<Attr>,
+    attrs: Vec<FieldAttr>,
 }
 
 impl<'a> ItemField<'a> {
@@ -57,7 +233,7 @@ impl<'a> ItemField<'a> {
             if let Some(it) = me
                 .attrs
                 .iter()
-                .find(|it| !matches!(it.kind, AttrKind::Flatten))
+                .find(|it| !matches!(it.kind, FieldAttrKind::Flatten))
             {
                 abort!(
                     it.ident,
@@ -71,25 +247,25 @@ impl<'a> ItemField<'a> {
     fn is_partition_key(&self) -> bool {
         self.attrs
             .iter()
-            .any(|attr| matches!(attr.kind, AttrKind::PartitionKey))
+            .any(|attr| matches!(attr.kind, FieldAttrKind::PartitionKey))
     }
 
     fn is_sort_key(&self) -> bool {
         self.attrs
             .iter()
-            .any(|attr| matches!(attr.kind, AttrKind::SortKey))
+            .any(|attr| matches!(attr.kind, FieldAttrKind::SortKey))
     }
 
     fn is_default_when_absent(&self) -> bool {
         self.attrs
             .iter()
-            .any(|attr| matches!(attr.kind, AttrKind::Default))
+            .any(|attr| matches!(attr.kind, FieldAttrKind::Default))
     }
 
     fn is_flatten(&self) -> bool {
         self.attrs
             .iter()
-            .any(|attr| matches!(attr.kind, AttrKind::Flatten))
+            .any(|attr| matches!(attr.kind, FieldAttrKind::Flatten))
     }
 
     fn deser_name(&self) -> String {
@@ -97,7 +273,7 @@ impl<'a> ItemField<'a> {
         attrs
             .iter()
             .find_map(|attr| match &attr.kind {
-                AttrKind::Rename(lit) => Some(lit.value()),
+                FieldAttrKind::Rename(lit) => Some(lit.value()),
                 _ => None,
             })
             .unwrap_or_else(|| {
@@ -110,12 +286,12 @@ impl<'a> ItemField<'a> {
     }
 }
 
-fn parse_attrs(all_attrs: &[Attribute]) -> Vec<Attr> {
+fn parse_attrs<A: Parse>(all_attrs: &[Attribute]) -> Vec<A> {
     all_attrs
         .iter()
         .filter(|attr| is_dynomite_attr(attr))
         .flat_map(|attr| {
-            attr.parse_args_with(Punctuated::<Attr, Token![,]>::parse_terminated)
+            attr.parse_args_with(Punctuated::<A, Token![,]>::parse_terminated)
                 .unwrap_or_abort()
         })
         .collect()
@@ -151,13 +327,7 @@ pub fn derive_item(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(Attributes, attributes(dynomite))]
 pub fn derive_attributes(input: TokenStream) -> TokenStream {
     let ast = syn::parse_macro_input!(input);
-
-    let gen = match expand_attributes(ast) {
-        Ok(g) => g,
-        Err(e) => return e.to_compile_error().into(),
-    };
-
-    gen.into_token_stream().into()
+    expand_attributes(ast).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
 /// Derives `dynomite::Attribute` for enum types
@@ -176,7 +346,7 @@ pub fn derive_attribute(input: TokenStream) -> TokenStream {
 fn expand_attribute(ast: DeriveInput) -> impl ToTokens {
     let name = &ast.ident;
     match ast.data {
-        Enum(variants) => {
+        syn::Data::Enum(variants) => {
             make_dynomite_attr(name, &variants.variants.into_iter().collect::<Vec<_>>())
         }
         _ => panic!("Dynomite Attributes can only be generated for enum types"),
@@ -205,7 +375,7 @@ fn expand_attribute(ast: DeriveInput) -> impl ToTokens {
 /// ```
 fn make_dynomite_attr(
     name: &Ident,
-    variants: &[Variant],
+    variants: &[syn::Variant],
 ) -> impl ToTokens {
     let attr = quote!(::dynomite::Attribute);
     let err = quote!(::dynomite::AttributeError);
@@ -244,21 +414,29 @@ fn make_dynomite_attr(
     }
 }
 
-fn expand_attributes(ast: DeriveInput) -> syn::Result<impl ToTokens> {
+fn expand_attributes(ast: DeriveInput) -> syn::Result<TokenStream> {
     use syn::spanned::Spanned as _;
-    let name = &ast.ident;
-    match ast.data {
-        Struct(DataStruct { fields, .. }) => match fields {
+    let name = ast.ident;
+    let tokens = match ast.data {
+        syn::Data::Struct(DataStruct { fields, .. }) => match fields {
             Fields::Named(named) => {
-                make_dynomite_attributes(name, &named.named.into_iter().collect::<Vec<_>>())
+                make_dynomite_attrs_for_struct(&name, &named.named.into_iter().collect::<Vec<_>>())
+                    .into_token_stream()
             }
-            fields => Err(syn::Error::new(
-                fields.span(),
-                "Dynomite Attributes require named fields",
-            )),
+            fields => {
+                return Err(syn::Error::new(
+                    fields.span(),
+                    "Dynomite Attributes require named fields",
+                ))
+            }
         },
+        syn::Data::Enum(data_enum) => {
+            make_dynomite_attrs_for_enum(&DataEnum::new(name, data_enum, &ast.attrs))
+                .into_token_stream()
+        }
         _ => panic!("Dynomite Attributes can only be generated for structs"),
-    }
+    };
+    Ok(tokens.into())
 }
 
 fn expand_item(ast: DeriveInput) -> syn::Result<impl ToTokens> {
@@ -266,7 +444,7 @@ fn expand_item(ast: DeriveInput) -> syn::Result<impl ToTokens> {
     let name = &ast.ident;
     let vis = &ast.vis;
     match ast.data {
-        Struct(DataStruct { fields, .. }) => match fields {
+        syn::Data::Struct(DataStruct { fields, .. }) => match fields {
             Fields::Named(named) => {
                 make_dynomite_item(vis, name, &named.named.into_iter().collect::<Vec<_>>())
             }
@@ -279,10 +457,20 @@ fn expand_item(ast: DeriveInput) -> syn::Result<impl ToTokens> {
     }
 }
 
-fn make_dynomite_attributes(
+fn make_dynomite_attrs_for_enum(enum_item: &DataEnum) -> impl ToTokens {
+    let from_attributes = enum_item.impl_from_attributes();
+    let into_attributes = enum_item.impl_into_attributes();
+
+    quote! {
+        #from_attributes
+        #into_attributes
+    }
+}
+
+fn make_dynomite_attrs_for_struct(
     name: &Ident,
     fields: &[Field],
-) -> syn::Result<impl ToTokens> {
+) -> impl ToTokens {
     let item_fields = fields.iter().map(ItemField::new).collect::<Vec<_>>();
     // impl ::dynomite::FromAttributes for Name
     let from_attribute_map = get_from_attributes_trait(name, &item_fields);
@@ -290,10 +478,10 @@ fn make_dynomite_attributes(
     // impl From<Name> for ::dynomite::Attributes
     let to_attribute_map = get_to_attribute_map_trait(name, &item_fields);
 
-    Ok(quote! {
+    quote! {
         #from_attribute_map
         #to_attribute_map
-    })
+    }
 }
 
 fn make_dynomite_item(

--- a/dynomite/trybuild-tests/fail/excess-values-attr.rs
+++ b/dynomite/trybuild-tests/fail/excess-values-attr.rs
@@ -1,0 +1,9 @@
+use dynomite_derive::Item;
+
+#[derive(Item)]
+pub struct S {
+    #[dynomite(partition_key = "bar")]
+    s: String,
+}
+
+fn main() {}

--- a/dynomite/trybuild-tests/fail/excess-values-attr.stderr
+++ b/dynomite/trybuild-tests/fail/excess-values-attr.stderr
@@ -1,0 +1,5 @@
+error: expected no value for dynomite attribute `partition_key`
+ --> $DIR/excess-values-attr.rs:5:16
+  |
+5 |     #[dynomite(partition_key = "bar")]
+  |                ^^^^^^^^^^^^^

--- a/dynomite/trybuild-tests/fail/fat-enum-without-tag.rs
+++ b/dynomite/trybuild-tests/fail/fat-enum-without-tag.rs
@@ -1,0 +1,13 @@
+use dynomite_derive::Attributes;
+
+#[derive(Attributes)]
+pub enum MyEnum {
+    Foo(Foo),
+}
+
+#[derive(Attributes)]
+pub struct Foo {
+    s: String,
+}
+
+fn main() {}

--- a/dynomite/trybuild-tests/fail/fat-enum-without-tag.stderr
+++ b/dynomite/trybuild-tests/fail/fat-enum-without-tag.stderr
@@ -1,0 +1,8 @@
+error: #[derive(Attributes)] for fat enums must have a sibling #[dynomite(tag = "key")] attribute to specify the descriptor field name.
+
+  = note: Only internally tagged enums are supported in this version of dynomite.
+
+ --> $DIR/fat-enum-without-tag.rs:4:10
+  |
+4 | pub enum MyEnum {
+  |          ^^^^^^

--- a/dynomite/trybuild-tests/fail/no-attr-value.rs
+++ b/dynomite/trybuild-tests/fail/no-attr-value.rs
@@ -1,0 +1,9 @@
+use dynomite_derive::Attributes;
+
+#[derive(Attributes)]
+struct Foo {
+    #[dynomite(rename)]
+    val: u32
+}
+
+fn main() {}

--- a/dynomite/trybuild-tests/fail/no-attr-value.stderr
+++ b/dynomite/trybuild-tests/fail/no-attr-value.stderr
@@ -1,0 +1,5 @@
+error: expected a value for dynomite attribute: `rename = "foo"`
+ --> $DIR/no-attr-value.rs:5:16
+  |
+5 |     #[dynomite(rename)]
+  |                ^^^^^^

--- a/dynomite/trybuild-tests/fail/non-unique-fat-enum-tags.rs
+++ b/dynomite/trybuild-tests/fail/non-unique-fat-enum-tags.rs
@@ -1,0 +1,15 @@
+use dynomite_derive::Attributes;
+
+#[derive(Attributes)]
+#[dynomite(tag = "kind")]
+enum Foo {
+    Bar(Bar),
+    #[dynomite(rename = "Bar")]
+    Baz(Bar),
+    Bruh(Bar),
+}
+
+#[derive(Attributes)]
+struct Bar {}
+
+fn main() {}

--- a/dynomite/trybuild-tests/fail/non-unique-fat-enum-tags.stderr
+++ b/dynomite/trybuild-tests/fail/non-unique-fat-enum-tags.stderr
@@ -1,0 +1,8 @@
+error: Duplicate tag name detected: `Bar`
+
+  = help: Please ensure that no `rename = "tag_value"` clauses conflict with each other and remaining enum variants' names
+
+ --> $DIR/non-unique-fat-enum-tags.rs:8:5
+  |
+8 |     Baz(Bar),
+  |     ^^^


### PR DESCRIPTION
~~**Blocked by** (these PRS have to reviewed and merged first before this one):~~
- [x] ~~#134~~
- [x] ~~#132~~

## [Internally tagged enums](https://serde.rs/enum-representations.html#internally-tagged)

The docs are pretty self-explanatory. This PR adds support for simple fat enums that have either one-element-tuple variants of the nested value of type `T` such that `T: Attributes`, or unit variants.

```rust
use dynomite::Attributes;

#[derive(Attributes)]
#[dynomite(tag = "kind")] // required to specify for fat enums
enum Shape {
    Rectangle(Rectangle),
    // Use `rename` to change the **value** of the tag for a particular variant
    // by default the tag for a particular variant is the name of the variant verbatim
    #[dynomite(rename = "my_circle")]
    Circle(Circle),
    Unknown,
}

#[derive(Attributes)]
struct Circle {
    radius: u32,
}

#[derive(Attributes)]
struct Rectangle {
    width: u32,
    height: u32,
}
```

These Rust definition correspond to the following representation in DynamoDB for each enum variant:

- `Rectangle`:
  ```json
  {
      "kind": "Rectangle",
      "width": 42,
      "height": 64
  }
  ```
- `Circle`:
  ```json
  {
      "kind": "my_circle",
      "radius": 54
  }
  ```
- `Unknown`:
  ```json
  {
      "kind": "Unknown"
  }
  ```

Closes: #131 

#### How did you verify your change:

Added a unit test, trybuild tests and doc tests

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
- Add initial support for fat enums (only one-element tuple variants of `T: Attributes` values and unit variants)