### PR TITLE
Support deriving Attribute trait for newtype structs

### DIFF
--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -277,6 +277,24 @@
 //!
 //! `role` field here may be any of `Admin`, `Moderator`, or `Regular` strings.
 //!
+//! #### Newtype Structs
+//!
+//! Types that implement the [dynomite::Attribute](trait.Attribute.html) trait can be wrapped in
+//! single-field tuple (newtype) structs. For example, a `String` newtype can be used as follows:
+//! ```rust
+//! use dynomite::{Attribute, Item};
+//!
+//! #[derive(Attribute)]
+//! struct Author(String);
+//!
+//! #[derive(Item)]
+//! struct Book {
+//!     #[dynomite(partition_key)]
+//!     id: String,
+//!     author: Author,
+//! }
+//! ```
+//!
 //! ## Rusoto extensions
 //!
 //! By importing the [dynomite::DynamoDbExt](trait.DynamoDbExt.html) trait, dynomite

--- a/dynomite/tests/derived.rs
+++ b/dynomite/tests/derived.rs
@@ -1,14 +1,20 @@
 use dynomite::{Attribute, Attributes, Item};
 use serde::{Deserialize, Serialize};
 
+#[derive(Attribute, Default, PartialEq, Debug, Clone, Serialize, Deserialize)]
+pub struct AuthorName(String);
+
 #[derive(Item, Default, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct Author {
     #[dynomite(partition_key)]
     // Test that the serde attr is not propagated to the generated key
     // Issue: https://github.com/softprops/dynomite/issues/121
     #[serde(rename = "Name")]
-    name: String,
+    name: AuthorName,
 }
+
+#[derive(Attribute, Default, PartialEq, Debug, Clone, Serialize, Deserialize)]
+pub struct NewAuthor(Author);
 
 #[derive(Attribute, PartialEq, Debug, Clone)]
 pub enum Category {


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

Previously, `#[derive(Attribute)]` only supported enums. This PR adds support for newtype structs as well (i.e., single-field tuple structs containing another `Attribute` type):
```rust
#[derive(Attribute)]
struct Author(String); // <-- `Author` transparently wraps `String` (zero-cost abstraction)

#[derive(Item)]
struct Book {
    #[dynomite(partition_key)]
    id: String,
    author: Author,
}
```

This functionality mirrors [`serde`'s behavior](https://github.com/serde-rs/serde-rs.github.io/issues/15).

#### How did you verify your change:

Added docs and a couple of test cases.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

No breaking changes; just a small new feature.