### PR TITLE
Add partition/sort key getters to Item trait

### DIFF
--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -397,8 +397,16 @@ pub type Attributes = HashMap<String, AttributeValue>;
 /// impl Item for Person {
 ///     fn key(&self) -> Attributes {
 ///         let mut attrs = HashMap::new();
-///         attrs.insert("id".into(), "123".to_string().into_attr());
+///         attrs.insert("id".into(), self.id.clone().into_attr());
 ///         attrs
+///     }
+///
+///     fn partition_key(&self) -> (String, AttributeValue) {
+///         ("id".into(), self.id.clone().into_attr())
+///     }
+///
+///     fn sort_key(&self) -> Option<(String, AttributeValue)> {
+///         None
 ///     }
 /// }
 ///
@@ -517,6 +525,12 @@ pub trait Item: IntoAttributes + FromAttributes {
     ///
     /// This is often used in item look ups
     fn key(&self) -> Attributes;
+
+    /// Returns a tuple containing the name and value of the partition key
+    fn partition_key(&self) -> (String, AttributeValue);
+
+    /// Returns a tuple containing the name and value of the sort key, if this item has one
+    fn sort_key(&self) -> Option<(String, AttributeValue)>;
 }
 
 /// A type capable of being converted into an or from and AWS `AttributeValue`

--- a/dynomite/tests/derived.rs
+++ b/dynomite/tests/derived.rs
@@ -25,6 +25,7 @@ impl Default for Category {
 pub struct Book {
     #[dynomite(partition_key)]
     title: String,
+    #[dynomite(sort_key)]
     category: Category,
     authors: Option<Vec<Author>>,
 }
@@ -130,6 +131,32 @@ mod tests {
             servings: 1,
         };
         assert_eq!(value.key(), RecipeKey { id: "test".into() }.into());
+        assert_eq!(
+            value.partition_key(),
+            ("RecipeId".to_string(), "test".to_string().into_attr())
+        );
+        assert!(value.sort_key().is_none());
+
+        let value = Book {
+            title: "rust".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            value.key(),
+            BookKey {
+                title: "rust".into(),
+                category: Category::Foo,
+            }
+            .into()
+        );
+        assert_eq!(
+            value.partition_key(),
+            ("title".to_string(), "rust".to_string().into_attr())
+        );
+        assert_eq!(
+            value.sort_key(),
+            Some(("category".to_string(), "Foo".to_string().into_attr()))
+        )
     }
 
     #[test]


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

The `Item` trait currently includes a `key()` method that returns a map from attribute name to attribute value for either the partition key only or both the partition and sort keys. In the latter case, it's not possible to distinguish between the partition and sort key attributes without separate knowledge about which key is which.

This PR adds `partition_key()` and `sort_key()` methods to the `Item` trait, which allow each key to be accessed separately. This makes it easier to write middleware and other generic code that works on multiple item types. Both methods are automatically implemented by the `derive` proc macro.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

#### How did you verify your change:

Added some test cases, plus tested the code manually from my (separate) downstream crate.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

Since this PR adds new methods to the `Item` trait without providing a default implementation, it constitutes a breaking change for users that manually implement this trait rather than using the `derive` proc macro.