### PR TITLE
Update to rusoto 0.46

### DIFF
--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -19,29 +19,47 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 async-trait = "0.1"
 again = "0.1"
-bytes = "0.5"
+bytes = "1"
 dynomite-derive = { version = "0.10.0", path = "../dynomite-derive", optional = true }
 futures = "0.3"
 log = "0.4"
-rusoto_core_default = { package = "rusoto_core", version = "0.45", optional = true }
-rusoto_core_rustls = { package = "rusoto_core", version = "0.45", default_features = false, features=["rustls"], optional = true }
-rusoto_dynamodb_default = { package = "rusoto_dynamodb", version = "0.45", optional = true }
-rusoto_dynamodb_rustls = { package = "rusoto_dynamodb", version = "0.45", default_features = false, features=["rustls"], optional = true }
+# Disable default features since the `rustls` variant requires it. We re-enable `default` in our
+# `default` build configuration - see the [features] below.
+rusoto_core = { version = "0.46", optional = true, default_features = false }
+rusoto_dynamodb = { version = "0.46", optional = true, default_features = false }
 uuid = { version = "0.8", features = ["v4"], optional = true }
 chrono = { version = "0.4", optional = true }
 
 [dev-dependencies]
-env_logger = "0.7"
+env_logger = "0.8"
 maplit = "1.0"
 serde = "1.0"
 serde_json = "1.0"
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1", features = ["macros"] }
 lambda_http = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "master"}
 trybuild = "1.0"
 rustversion = "1.0"
 dynomite-derive = { version = "0.10.0", path = "../dynomite-derive" } # required by trybuild
 
 [features]
-default = ["uuid", "chrono", "derive", "rusoto_core_default", "rusoto_dynamodb_default"]
-rustls = ["uuid", "chrono", "derive", "rusoto_core_rustls", "rusoto_dynamodb_rustls"]
+default = [
+  "uuid",
+  "chrono",
+  "derive",
+  "rusoto_core",
+  "rusoto_dynamodb",
+  # Enable the `default` features of these crates.
+  "rusoto_core/default",
+  "rusoto_dynamodb/default"
+]
+
+rustls = [
+  "uuid",
+  "chrono",
+  "derive",
+  "rusoto_core",
+  "rusoto_dynamodb",
+  "rusoto_core/rustls",
+  "rusoto_dynamodb/rustls"
+]
 derive = ["dynomite-derive"]

--- a/dynomite/src/ext.rs
+++ b/dynomite/src/ext.rs
@@ -5,10 +5,7 @@ use crate::dynamodb::{
     ListTablesInput, QueryError, QueryInput, ScanError, ScanInput,
 };
 use futures::{stream, Stream, TryStreamExt};
-#[cfg(feature = "default")]
-use rusoto_core_default::RusotoError;
-#[cfg(feature = "rustls")]
-use rusoto_core_rustls::RusotoError;
+use rusoto_core::RusotoError;
 use std::{collections::HashMap, pin::Pin};
 
 type DynomiteStream<I, E> = Pin<Box<dyn Stream<Item = Result<I, RusotoError<E>>> + Send>>;

--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -340,11 +340,11 @@
 #![deny(missing_docs)]
 // reexported
 // note: this is used inside the attr_map! macro
-#[cfg(feature = "default")]
-pub use rusoto_dynamodb_default as dynamodb;
-
-#[cfg(feature = "rustls")]
-pub use rusoto_dynamodb_rustls as dynamodb;
+// #[cfg(feature = "default")]
+// pub use rusoto_dynamodb_default as dynamodb;
+//
+// #[cfg(feature = "rustls")]
+// pub use rusoto_dynamodb_rustls as dynamodb;
 
 use bytes::Bytes;
 #[cfg(feature = "chrono")]
@@ -352,6 +352,7 @@ use chrono::{
     offset::{FixedOffset, Local},
     DateTime, Utc,
 };
+pub use rusoto_dynamodb as dynamodb;
 
 // we re-export this because we
 // refer to it with in derive macros

--- a/dynomite/src/retry.rs
+++ b/dynomite/src/retry.rs
@@ -869,6 +869,7 @@ where
         RusotoError<DisableKinesisStreamingDestinationError>,
     > {
         self.inner
+            .client
             .disable_kinesis_streaming_destination(input)
             .await
     }

--- a/dynomite/src/retry.rs
+++ b/dynomite/src/retry.rs
@@ -20,10 +20,7 @@
 use crate::dynamodb::*;
 use again::{Condition, RetryPolicy};
 use log::debug;
-#[cfg(feature = "default")]
-use rusoto_core_default::RusotoError;
-#[cfg(feature = "rustls")]
-use rusoto_core_rustls::RusotoError;
+use rusoto_core::RusotoError;
 use std::{sync::Arc, time::Duration};
 
 /// Pre-configured retry policies for fallible operations
@@ -304,6 +301,13 @@ where
             .await
     }
 
+    async fn describe_export(
+        &self,
+        input: DescribeExportInput,
+    ) -> Result<DescribeExportOutput, RusotoError<DescribeExportError>> {
+        self.inner.client.describe_export(input).await
+    }
+
     async fn describe_continuous_backups(
         &self,
         input: DescribeContinuousBackupsInput,
@@ -458,6 +462,13 @@ where
                 Counter(0),
             )
             .await
+    }
+
+    async fn list_exports(
+        &self,
+        input: ListExportsInput,
+    ) -> Result<ListExportsOutput, RusotoError<ListExportsError>> {
+        self.inner.client.list_exports(input).await
     }
 
     async fn list_contributor_insights(
@@ -801,6 +812,72 @@ where
                 Counter(0),
             )
             .await
+    }
+
+    async fn batch_execute_statement(
+        &self,
+        input: BatchExecuteStatementInput,
+    ) -> Result<BatchExecuteStatementOutput, RusotoError<BatchExecuteStatementError>> {
+        self.inner.client.batch_execute_statement(input).await
+    }
+
+    async fn execute_statement(
+        &self,
+        input: ExecuteStatementInput,
+    ) -> Result<ExecuteStatementOutput, RusotoError<ExecuteStatementError>> {
+        self.inner.client.execute_statement(input).await
+    }
+
+    async fn execute_transaction(
+        &self,
+        input: ExecuteTransactionInput,
+    ) -> Result<ExecuteTransactionOutput, RusotoError<ExecuteTransactionError>> {
+        self.inner.client.execute_transaction(input).await
+    }
+
+    async fn describe_kinesis_streaming_destination(
+        &self,
+        input: DescribeKinesisStreamingDestinationInput,
+    ) -> Result<
+        DescribeKinesisStreamingDestinationOutput,
+        RusotoError<DescribeKinesisStreamingDestinationError>,
+    > {
+        self.inner
+            .client
+            .describe_kinesis_streaming_destination(input)
+            .await
+    }
+
+    async fn enable_kinesis_streaming_destination(
+        &self,
+        input: KinesisStreamingDestinationInput,
+    ) -> Result<
+        KinesisStreamingDestinationOutput,
+        RusotoError<EnableKinesisStreamingDestinationError>,
+    > {
+        self.inner
+            .client
+            .enable_kinesis_streaming_destination(input)
+            .await
+    }
+
+    async fn disable_kinesis_streaming_destination(
+        &self,
+        input: KinesisStreamingDestinationInput,
+    ) -> Result<
+        KinesisStreamingDestinationOutput,
+        RusotoError<DisableKinesisStreamingDestinationError>,
+    > {
+        self.inner
+            .disable_kinesis_streaming_destination(input)
+            .await
+    }
+
+    async fn export_table_to_point_in_time(
+        &self,
+        input: ExportTableToPointInTimeInput,
+    ) -> Result<ExportTableToPointInTimeOutput, RusotoError<ExportTableToPointInTimeError>> {
+        self.inner.client.export_table_to_point_in_time(input).await
     }
 }
 


### PR DESCRIPTION
Small refactor to simplify rustls feature usage.

<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:
* Update rusoto dependencies to 0.46. This includes updating the `retry::RetryingDynamoDB` implementation to include the newly added methods. I have never used any of those methods, so I don't know which ones should be retried - as such I implemented all of them by deferring directly to the inner client.
* Updated a few other dependencies - notably `tokio` to 1.0.
* Small internal refactor of how the `rusoto_*` libraries are handled - I changed this because my editor configuration disagreed with how it was being done. You can specify features to pass through to dependencies - so the `default` passes `rusoto_dynamodb/default` and `rustls` passes `rusto_dynamodb/rustls`, etc.

#### How did you verify your change:

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
Upgrade to rusoto 0.46.