### PR TITLE
fix test item-not-on-struct-fail's expected stderr to include error code

### DIFF
--- a/dynomite/trybuild-tests/fail/item-not-on-struct-fail.stderr
+++ b/dynomite/trybuild-tests/fail/item-not-on-struct-fail.stderr
@@ -1,4 +1,4 @@
-error: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to structs, enums and unions
  --> $DIR/item-not-on-struct-fail.rs:9:1
   |
 9 | #[derive(Item)]


### PR DESCRIPTION
~Note that this sits on top of #150 (to avoid CI failing due to those issues) and if/once that is merged this should be rebased on top of then-`master` such that this PR contains only relevant commits.  Of course if this is wanted without waiting on #150, those commits can be rebased away from this PR's head repo/branch as desired.~

#150 has been merged and this PR has been rebased on top of the new `master`, so this can be merged.

---

## What did you implement:

Testing compilation error of `#[derive(Item)]` on a non-`struct` (`item-not-on-struct-fail`) failed due to missing error code in the expected stderr content, so I've added the code.

#### How did you verify your change:

```
$ cargo t
...
test item-not-on-struct-fail.rs [should fail to compile] ... ok
...
```