### PR TITLE
Upgrade Rusoto deps to 0.47

### DIFF
--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3"
 log = "0.4"
 # Disable default features since the `rustls` variant requires it. We re-enable `default` in our
 # `default` build configuration - see the [features] below.
-rusoto_core = { version = "0.46", optional = true, default_features = false }
-rusoto_dynamodb = { version = "0.46", optional = true, default_features = false }
+rusoto_core = { version = "0.47", optional = true, default_features = false }
+rusoto_dynamodb = { version = "0.47", optional = true, default_features = false }
 uuid = { version = "0.8", features = ["v4"], optional = true }
 chrono = { version = "0.4", optional = true }
 


### PR DESCRIPTION
## What did you implement:
Upgrade Rusoto to 0.47, which will allow users of dynamite to ease upgrading to Rusoto 0.47.

#### How did you verify your change:
Ran `cargo check && cargo test` with nightly 2021-09-18
#### What (if anything) would need to be called out in the CHANGELOG for the next release:
Upgrade Rusoto to 0.47.