### PR TITLE
Fix apostrophe typo in error message

### DIFF
--- a/dynomite-derive/src/lib.rs
+++ b/dynomite-derive/src/lib.rs
@@ -503,7 +503,7 @@ fn make_dynomite_item(
         return Err(syn::Error::new(
             name.span(),
             format!(
-                "All Item's must declare one and only one partition_key. The `{}` Item declared {}",
+                "All items must declare one and only one partition_key. The `{}` Item declared {}",
                 name, partition_key_count
             ),
         ));


### PR DESCRIPTION
👋 Super excited that this project exists!

This PR fixes a small typo in an error message returned by `make_dynomite_item`. There shouldn't be an apostrophe here because, in this phrase, the item isn't being used as as a possessive.