### PR TITLE
Upgrade `uuid` to version 1.1.2

### DIFF
--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3"
 log = "0.4"
 # Disable default features since the `rustls` variant requires it. We re-enable `default` in our
 # `default` build configuration - see the [features] below.
-rusoto_core = { version = "0.47", optional = true, default_features = false }
-rusoto_dynamodb = { version = "0.47", optional = true, default_features = false }
+rusoto_core = { version = "0.48", optional = true, default_features = false }
+rusoto_dynamodb = { version = "0.48", optional = true, default_features = false }
 uuid = { version = "1.1.2", features = ["v4"], optional = true }
 chrono = { version = "0.4", optional = true }
 

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4"
 # `default` build configuration - see the [features] below.
 rusoto_core = { version = "0.47", optional = true, default_features = false }
 rusoto_dynamodb = { version = "0.47", optional = true, default_features = false }
-uuid = { version = "0.8", features = ["v4"], optional = true }
+uuid = { version = "1.1.2", features = ["v4"], optional = true }
 chrono = { version = "0.4", optional = true }
 
 [dev-dependencies]

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3"
 log = "0.4"
 # Disable default features since the `rustls` variant requires it. We re-enable `default` in our
 # `default` build configuration - see the [features] below.
-rusoto_core = { version = "0.48", optional = true, default_features = false }
-rusoto_dynamodb = { version = "0.48", optional = true, default_features = false }
+rusoto_core = { git = "https://github.com/sameer/rusoto.git", rev = "0346b41b414d036eb54cdf64781a17ba4b1a8ba4", optional = true, default_features = false }
+rusoto_dynamodb = { git = "https://github.com/sameer/rusoto.git", rev = "0346b41b414d036eb54cdf64781a17ba4b1a8ba4", version = "0.48", optional = true, default_features = false }
 uuid = { version = "1.1.2", features = ["v4"], optional = true }
 chrono = { version = "0.4", optional = true }
 

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -36,7 +36,7 @@ maplit = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros"] }
-lambda_http = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "master"}
+lambda_http = "0.5.2"
 trybuild = "1.0"
 rustversion = "1.0"
 dynomite-derive = { version = "0.10.0", path = "../dynomite-derive" } # required by trybuild

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3"
 log = "0.4"
 # Disable default features since the `rustls` variant requires it. We re-enable `default` in our
 # `default` build configuration - see the [features] below.
-rusoto_core = { git = "https://github.com/sameer/rusoto.git", rev = "8c63670d45563ba8be2a42dcd265d49ae340ccd8", optional = true, default_features = false }
-rusoto_dynamodb = { git = "https://github.com/sameer/rusoto.git", rev = "8c63670d45563ba8be2a42dcd265d49ae340ccd8", version = "0.48", optional = true, default_features = false }
+rusoto_core = { git = "https://github.com/getditto/rusoto.git", rev = "8c63670d45563ba8be2a42dcd265d49ae340ccd8", optional = true, default_features = false }
+rusoto_dynamodb = { git = "https://github.com/getditto/rusoto.git", rev = "8c63670d45563ba8be2a42dcd265d49ae340ccd8", version = "0.48", optional = true, default_features = false }
 uuid = { version = "1.1.2", features = ["v4"], optional = true }
 chrono = { version = "0.4", optional = true }
 

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3"
 log = "0.4"
 # Disable default features since the `rustls` variant requires it. We re-enable `default` in our
 # `default` build configuration - see the [features] below.
-rusoto_core = { git = "https://github.com/sameer/rusoto.git", rev = "0346b41b414d036eb54cdf64781a17ba4b1a8ba4", optional = true, default_features = false }
-rusoto_dynamodb = { git = "https://github.com/sameer/rusoto.git", rev = "0346b41b414d036eb54cdf64781a17ba4b1a8ba4", version = "0.48", optional = true, default_features = false }
+rusoto_core = { git = "https://github.com/sameer/rusoto.git", rev = "8c63670d45563ba8be2a42dcd265d49ae340ccd8", optional = true, default_features = false }
+rusoto_dynamodb = { git = "https://github.com/sameer/rusoto.git", rev = "8c63670d45563ba8be2a42dcd265d49ae340ccd8", version = "0.48", optional = true, default_features = false }
 uuid = { version = "1.1.2", features = ["v4"], optional = true }
 chrono = { version = "0.4", optional = true }
 

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3"
 log = "0.4"
 # Disable default features since the `rustls` variant requires it. We re-enable `default` in our
 # `default` build configuration - see the [features] below.
-rusoto_core = { git = "https://github.com/getditto/rusoto.git", rev = "8c63670d45563ba8be2a42dcd265d49ae340ccd8", optional = true, default_features = false }
-rusoto_dynamodb = { git = "https://github.com/getditto/rusoto.git", rev = "8c63670d45563ba8be2a42dcd265d49ae340ccd8", version = "0.48", optional = true, default_features = false }
+rusoto_core = { git = "https://github.com/getditto/rusoto.git", rev = "a167fb4fd2d0b3b3f8d191d1d905fe8a60f66a3a", optional = true, default_features = false }
+rusoto_dynamodb = { git = "https://github.com/getditto/rusoto.git", rev = "a167fb4fd2d0b3b3f8d191d1d905fe8a60f66a3a", version = "0.48", optional = true, default_features = false }
 uuid = { version = "1.1.2", features = ["v4"], optional = true }
 chrono = { version = "0.4", optional = true }
 

--- a/dynomite/examples/lambda.rs
+++ b/dynomite/examples/lambda.rs
@@ -3,7 +3,7 @@ use dynomite::{
     retry::Policy,
     Retries,
 };
-use lambda_http::{handler, lambda_runtime};
+use lambda_http::service_fn;
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -11,7 +11,7 @@ type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 async fn main() -> Result<(), Error> {
     let client = DynamoDbClient::new(Default::default()).with_retries(Policy::default());
 
-    lambda_runtime::run(handler(move |_, _| {
+    lambda_http::run(service_fn(move |_| {
         let client = client.clone();
         async move {
             let tables = client

--- a/dynomite/src/lib.rs
+++ b/dynomite/src/lib.rs
@@ -683,7 +683,7 @@ impl<T: IntoAttributes + FromAttributes> Attribute for T {
 impl Attribute for Uuid {
     fn into_attr(self) -> AttributeValue {
         AttributeValue {
-            s: Some(self.to_hyphenated().to_string()),
+            s: Some(self.hyphenated().to_string()),
             ..AttributeValue::default()
         }
     }

--- a/dynomite/trybuild-tests/fail/fat-enum-without-tag.stderr
+++ b/dynomite/trybuild-tests/fail/fat-enum-without-tag.stderr
@@ -1,6 +1,6 @@
 error: #[derive(Attributes)] for fat enums must have a sibling #[dynomite(tag = "key")] attribute to specify the descriptor field name.
 
-  = note: Only internally tagged enums are supported in this version of dynomite.
+         = note: Only internally tagged enums are supported in this version of dynomite.
 
  --> $DIR/fat-enum-without-tag.rs:4:10
   |

--- a/dynomite/trybuild-tests/fail/item-not-on-struct-fail.stderr
+++ b/dynomite/trybuild-tests/fail/item-not-on-struct-fail.stderr
@@ -1,5 +1,9 @@
-error[E0774]: `derive` may only be applied to structs, enums and unions
- --> $DIR/item-not-on-struct-fail.rs:7:1
-  |
-7 | #[derive(dynomite_derive::Item)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
+  --> $DIR/item-not-on-struct-fail.rs:7:1
+   |
+7  |   #[derive(dynomite_derive::Item)]
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not applicable here
+8  | / fn fail() {
+9  | |   println!("This should fail");
+10 | | }
+   | |_- not a `struct`, `enum` or `union`

--- a/dynomite/trybuild-tests/fail/non-unique-fat-enum-tags.stderr
+++ b/dynomite/trybuild-tests/fail/non-unique-fat-enum-tags.stderr
@@ -1,6 +1,6 @@
 error: Duplicate tag name detected: `Bar`
 
-  = help: Please ensure that no `rename = "tag_value"` clauses conflict with each other and remaining enum variants' names
+         = help: Please ensure that no `rename = "tag_value"` clauses conflict with each other and remaining enum variants' names
 
  --> $DIR/non-unique-fat-enum-tags.rs:8:5
   |


### PR DESCRIPTION
`uuid` has made a [major 1.0.0 release](https://github.com/uuid-rs/uuid/releases/tag/1.0.0) and subsequent releases up to 1.1.2. Depending on `dynomite` while trying to upgrade `uuid` results in errors due to multiple crate versions.
 
## What did you implement:
- Upgrade `lambda_http` to version 0.5.2
- Upgrade `uuid` to version 1.1.2
- Update failing trybuild test cases

#### How did you verify your change:
By running:
```
cargo build --all-targets
cargo test
```

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
The new `uuid` version should probably be called out.