### PR TITLE
Update rusoto to 0.48

### DIFF
--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3"
 log = "0.4"
 # Disable default features since the `rustls` variant requires it. We re-enable `default` in our
 # `default` build configuration - see the [features] below.
-rusoto_core = { version = "0.47", optional = true, default_features = false }
-rusoto_dynamodb = { version = "0.47", optional = true, default_features = false }
+rusoto_core = { version = "0.48", optional = true, default_features = false }
+rusoto_dynamodb = { version = "0.48", optional = true, default_features = false }
 uuid = { version = "0.8", features = ["v4"], optional = true }
 chrono = { version = "0.4", optional = true }
 


### PR DESCRIPTION
## What did you implement:

Update rusoto to 0.48

#### How did you verify your change:

Ran tests using `cargo test`

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

N/A